### PR TITLE
Added CALL and RET operators for function-like control flow.

### DIFF
--- a/src/main/java/li/cil/tis3d/common/module/execution/MachineState.java
+++ b/src/main/java/li/cil/tis3d/common/module/execution/MachineState.java
@@ -26,6 +26,11 @@ public final class MachineState {
      * Program counter, i.e. the index of the next operation to execute.
      */
     public int pc = 0;
+    
+    /**
+     * Address ret should return to.
+     */
+    public int reta = 0;
 
     /**
      * Accumulator register.
@@ -53,6 +58,7 @@ public final class MachineState {
     // NBT tag names.
     public static final String TAG_CODE = "code";
     public static final String TAG_PC = "pc";
+    public static final String TAG_RETA = "reta";
     public static final String TAG_ACC = "acc";
     public static final String TAG_BAK = "bak";
     public static final String TAG_LAST = "last";
@@ -90,6 +96,7 @@ public final class MachineState {
      */
     public void reset() {
         pc = 0;
+        reta = 0;
         acc = 0;
         bak = 0;
         last = Optional.empty();
@@ -122,6 +129,7 @@ public final class MachineState {
         }
 
         pc = nbt.getInteger(TAG_PC);
+        reta = nbt.getInteger(TAG_RETA);
         acc = nbt.getShort(TAG_ACC);
         bak = nbt.getShort(TAG_BAK);
         if (nbt.hasKey(TAG_LAST)) {
@@ -135,6 +143,7 @@ public final class MachineState {
 
     public void writeToNBT(final NBTTagCompound nbt) {
         nbt.setInteger(TAG_PC, pc);
+        nbt.setInteger(TAG_RETA, reta);
         nbt.setShort(TAG_ACC, acc);
         nbt.setShort(TAG_BAK, bak);
         last.ifPresent(port -> EnumUtils.writeToNBT(port, TAG_LAST, nbt));

--- a/src/main/java/li/cil/tis3d/common/module/execution/compiler/Compiler.java
+++ b/src/main/java/li/cil/tis3d/common/module/execution/compiler/Compiler.java
@@ -25,6 +25,7 @@ import li.cil.tis3d.common.module.execution.instruction.InstructionBitwiseShiftR
 import li.cil.tis3d.common.module.execution.instruction.InstructionBitwiseShiftRightImmediate;
 import li.cil.tis3d.common.module.execution.instruction.InstructionBitwiseXor;
 import li.cil.tis3d.common.module.execution.instruction.InstructionBitwiseXorImmediate;
+import li.cil.tis3d.common.module.execution.instruction.InstructionCall;
 import li.cil.tis3d.common.module.execution.instruction.InstructionHaltAndCatchFire;
 import li.cil.tis3d.common.module.execution.instruction.InstructionJump;
 import li.cil.tis3d.common.module.execution.instruction.InstructionJumpEqualZero;
@@ -34,6 +35,7 @@ import li.cil.tis3d.common.module.execution.instruction.InstructionJumpNotZero;
 import li.cil.tis3d.common.module.execution.instruction.InstructionJumpRelative;
 import li.cil.tis3d.common.module.execution.instruction.InstructionJumpRelativeImmediate;
 import li.cil.tis3d.common.module.execution.instruction.InstructionNegate;
+import li.cil.tis3d.common.module.execution.instruction.InstructionReturn;
 import li.cil.tis3d.common.module.execution.instruction.InstructionSave;
 import li.cil.tis3d.common.module.execution.instruction.InstructionSubtract;
 import li.cil.tis3d.common.module.execution.instruction.InstructionSubtractImmediate;
@@ -182,6 +184,10 @@ public final class Compiler {
         addInstructionEmitter(builder, new InstructionEmitterLabel("JLZ", InstructionJumpLessThanZero::new));
         addInstructionEmitter(builder, new InstructionEmitterLabel("JNZ", InstructionJumpNotZero::new));
         addInstructionEmitter(builder, new InstructionEmitterTargetOrImmediate("JRO", InstructionJumpRelative::new, InstructionJumpRelativeImmediate::new));
+        
+        //Call and Return.
+        addInstructionEmitter(builder, new InstructionEmitterLabel("CALL", InstructionCall::new));
+        addInstructionEmitter(builder, new InstructionEmitterUnary("RET", InstructionReturn::new));
 
         // Data transfer.
         addInstructionEmitter(builder, new InstructionEmitterMove());

--- a/src/main/java/li/cil/tis3d/common/module/execution/instruction/InstructionCall.java
+++ b/src/main/java/li/cil/tis3d/common/module/execution/instruction/InstructionCall.java
@@ -1,0 +1,24 @@
+package li.cil.tis3d.common.module.execution.instruction;
+
+import li.cil.tis3d.common.module.execution.Machine;
+import li.cil.tis3d.common.module.execution.MachineState;
+
+public final class InstructionCall implements Instruction {
+    private final String label;
+
+    public InstructionCall(final String label) {
+        this.label = label;
+    }
+
+    @Override
+    public void step(final Machine machine) {
+        final MachineState state = machine.getState();
+        state.reta = state.pc + 1;
+        state.pc = state.labels.get(label);
+    }
+
+    @Override
+    public String toString() {
+        return "CALL " + label;
+    }
+}

--- a/src/main/java/li/cil/tis3d/common/module/execution/instruction/InstructionReturn.java
+++ b/src/main/java/li/cil/tis3d/common/module/execution/instruction/InstructionReturn.java
@@ -1,0 +1,23 @@
+package li.cil.tis3d.common.module.execution.instruction;
+
+import li.cil.tis3d.common.module.execution.Machine;
+import li.cil.tis3d.common.module.execution.MachineState;
+
+public final class InstructionReturn implements Instruction {
+    public InstructionReturn() {
+        
+    }
+
+    @Override
+    public void step(final Machine machine) {
+        final MachineState state = machine.getState();
+        System.out.println(state.reta);
+        state.pc = state.reta;
+        state.reta = 0;
+    }
+
+    @Override
+    public String toString() {
+        return "RET";
+    }
+}

--- a/src/main/resources/assets/tis3d/doc/en_US/item/moduleExecution.md
+++ b/src/main/resources/assets/tis3d/doc/en_US/item/moduleExecution.md
@@ -105,3 +105,9 @@ If the current value of `ACC` is *less than* zero (0), jump to the instruction r
 
 `JRO <SRC>`
 Unconditionally jump to a relative address, read from the specified target `SRC`. This modifies the program counter by adding the value read from `SRC` to it. Execution resumes at the new address. `JRO 0` effectively halts the execution module indefinitely.
+
+`CALL <LABEL>`
+Unconditionally jumps to the instruction referenced by the specified label `LABEL`. It also stores the address of the next instruction for use by `RET`.
+
+`RET`
+Jumps to the instruction after the most recent `CALL`. If `CALL` has not been used yet in the program it defaults to jump to the beginning of the program.


### PR DESCRIPTION
This adds the CALL and RET keywords to TIS-3D. They work the same as in normal assembly language (I think), and didn't take all that many changes to implement. 

One notable change is the addition of a new variable to MachineState which stores the return address (reta) that RET should jump to.
