### PR TITLE
Fix crash when providing invalid instrument value to AudioModule

### DIFF
--- a/src/main/java/li/cil/tis3d/common/module/ModuleAudio.java
+++ b/src/main/java/li/cil/tis3d/common/module/ModuleAudio.java
@@ -114,6 +114,11 @@ public final class ModuleAudio extends AbstractModule {
             return;
         }
 
+        // Skip invalid instruments
+        if (instrumentId >= INSTRUMENTS.length) {
+            return;
+        }
+
         // Send event to check if the sound may be played / should be modulated.
         final World world = getCasing().getCasingWorld();
         final BlockPos pos = getCasing().getPosition();


### PR DESCRIPTION
By providing invalid instrument id's to the AudioModule the game crashed with ArrayIndexOutOfBounds:

```
java.lang.ArrayIndexOutOfBoundsException: 5
	at li.cil.tis3d.common.module.ModuleAudio.playNote(ModuleAudio.java:125)
	at li.cil.tis3d.common.module.ModuleAudio.stepInput(ModuleAudio.java:93)
	at li.cil.tis3d.common.module.ModuleAudio.step(ModuleAudio.java:58)
	at li.cil.tis3d.common.machine.CasingImpl.stepModules(CasingImpl.java:119)
	at li.cil.tis3d.common.tileentity.TileEntityCasing.stepModules(TileEntityCasing.java:221)
	at java.util.ArrayList.forEach(ArrayList.java:1251)
	at li.cil.tis3d.common.tileentity.TileEntityController.step(TileEntityController.java:520)
	at li.cil.tis3d.common.tileentity.TileEntityController.update(TileEntityController.java:358)
	at net.minecraft.world.World.updateEntities(World.java:1807)
	at net.minecraft.world.WorldServer.updateEntities(WorldServer.java:614)
	at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:761)
	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:665)
	at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:185)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:523)
	at java.lang.Thread.run(Thread.java:748)
```

I fixed it by simply returning when the instrumentId is out of bounds of the INSTRUMENTS array.

I hope that pull requesting into this branch is fine and you can merge this change back into the other branches.