### PR TITLE
Making extension mods work under fabric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "net.fabricmc:fabric-loom:0.2.7-SNAPSHOT"
+        classpath "net.fabricmc:fabric-loom:0.4-SNAPSHOT"
     }
 }
 

--- a/build.properties
+++ b/build.properties
@@ -1,8 +1,8 @@
-minecraft.simpleversion=1.16.1
-minecraft.version=com.mojang:minecraft:1.16.1
-fabric.mappings=net.fabricmc:yarn:1.16.1+build.21:v2
+minecraft.simpleversion=1.16.2-rc1
+minecraft.version=com.mojang:minecraft:1.16.2-rc1
+fabric.mappings=net.fabricmc:yarn:1.16.2-rc1+build.4
 fabric.loader=net.fabricmc:fabric-loader:0.9.0+build.204
-fabric.api=net.fabricmc.fabric-api:fabric-api:0.16.2+build.385-1.16.1
+fabric.api=net.fabricmc.fabric-api:fabric-api:0.17.0+build.393-1.16
 
 mod.name=TIS-3D
 mod.group=li.cil.tis3d

--- a/src/main/java/li/cil/tis3d/api/API.java
+++ b/src/main/java/li/cil/tis3d/api/API.java
@@ -15,6 +15,11 @@ public final class API {
 
     public static ItemGroup itemGroup;
 
+    public enum Font {
+        SmallFont,
+        NormalFont
+    }
+
     // Set in TIS-3D pre-init, prefer using static entry point classes instead.
     public static li.cil.tis3d.api.detail.FontRendererAPI fontRendererAPI;
     public static li.cil.tis3d.api.detail.InfraredAPI infraredAPI;

--- a/src/main/java/li/cil/tis3d/api/ClientExtInitializer.java
+++ b/src/main/java/li/cil/tis3d/api/ClientExtInitializer.java
@@ -1,0 +1,6 @@
+package li.cil.tis3d.api;
+
+@FunctionalInterface
+public interface ClientExtInitializer {
+    void onInitializeClient();
+}

--- a/src/main/java/li/cil/tis3d/api/ExtInitializer.java
+++ b/src/main/java/li/cil/tis3d/api/ExtInitializer.java
@@ -1,0 +1,6 @@
+package li.cil.tis3d.api;
+
+@FunctionalInterface
+public interface ExtInitializer {
+    void onInitialize();
+}

--- a/src/main/java/li/cil/tis3d/api/detail/FontRendererAPI.java
+++ b/src/main/java/li/cil/tis3d/api/detail/FontRendererAPI.java
@@ -1,7 +1,11 @@
 package li.cil.tis3d.api.detail;
 
+import li.cil.tis3d.api.API;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
 
 /**
  * API entry point for access to the tiny font renderer used on execution
@@ -29,6 +33,12 @@ public interface FontRendererAPI {
      * @param maxChars the maximum number of characters to render.
      */
     void drawString(final String string, final int maxChars);
+
+    void drawString(final API.Font font, final MatrixStack.Entry matrices, final VertexConsumer vc,
+                    final int light, final int overlay, final int color,
+                    final CharSequence value, final int maxChars);
+
+    VertexConsumer chooseVertexConsumer(final API.Font font, final VertexConsumerProvider vcp);
 
     /**
      * Get the width of the characters drawn with the font renderer, in pixels.

--- a/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
@@ -24,7 +24,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.text.LiteralText;
-import net.minecraft.text.StringRenderable;
+import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Hand;
 import org.lwjgl.glfw.GLFW;
@@ -102,7 +102,7 @@ public final class CodeBookGui extends Screen {
             rebuildLines();
         }));
 
-        client.keyboard.enableRepeatEvents(true);
+        client.keyboard.setRepeatEvents(true);
     }
 
     @Override
@@ -117,7 +117,7 @@ public final class CodeBookGui extends Screen {
         data.writeToNBT(nbt);
         Network.INSTANCE.sendToServer(new CodeBookDataMessage(nbt, hand));
 
-        client.keyboard.enableRepeatEvents(false);
+        client.keyboard.setRepeatEvents(false);
     }
 
     @Override
@@ -644,7 +644,7 @@ public final class CodeBookGui extends Screen {
 
             // Part two of error handling, draw tooltip, *on top* of blinking cursor.
             if (mouseX >= startX && mouseX <= endX && mouseY >= startY && mouseY <= startY + getTextRenderer().fontHeight) {
-                final List<StringRenderable> tooltip = new ArrayList<>();
+                final List<Text> tooltip = new ArrayList<>();
                 if (isErrorOnPreviousPage) {
                     tooltip.add(new TranslatableText(Constants.MESSAGE_ERROR_ON_PREVIOUS_PAGE));
                 } else if (isErrorOnNextPage) {
@@ -652,7 +652,7 @@ public final class CodeBookGui extends Screen {
                 }
                 final String translatedException = I18n.translate(exception.getMessage());
                 final List<String> lines = Arrays.asList(Constants.PATTERN_LINES.split(translatedException));
-                tooltip.addAll(lines.stream().map(StringRenderable::plain).collect(Collectors.toList()));
+                tooltip.addAll(lines.stream().map(Text::of).collect(Collectors.toList()));
                 renderTooltip(matrices, tooltip, mouseX, mouseY);
                 GlStateManager.disableLighting();
             }

--- a/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
@@ -22,7 +22,6 @@ import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.Window;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
-import net.minecraft.text.StringRenderable;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
@@ -146,7 +145,7 @@ public final class ManualGui extends Screen {
         }
 
         if (canScroll() && (isCoordinateOverScrollBar(mouseX - guiLeft, mouseY - guiTop) || isDragging)) {
-            renderTooltip(matrices, StringRenderable.plain(100 * offset() / maxOffset() + "%"), guiLeft + SCROLL_POS_X + SCROLL_WIDTH, scrollButton.y + scrollButton.getHeight() + 1);
+            renderTooltip(matrices, new LiteralText(100 * offset() / maxOffset() + "%"), guiLeft + SCROLL_POS_X + SCROLL_WIDTH, scrollButton.y + scrollButton.getHeight() + 1);
         }
     }
 

--- a/src/main/java/li/cil/tis3d/client/gui/ReadOnlyMemoryModuleGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ReadOnlyMemoryModuleGui.java
@@ -59,7 +59,7 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
         guiX = (width - GUI_WIDTH) / 2;
         guiY = (height - GUI_HEIGHT) / 2;
 
-        client.keyboard.enableRepeatEvents(true);
+        client.keyboard.setRepeatEvents(true);
     }
 
     @Override
@@ -73,7 +73,7 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
             Network.INSTANCE.sendToServer(new ReadOnlyMemoryModuleDataMessage(data, hand));
         }
 
-        client.keyboard.enableRepeatEvents(false);
+        client.keyboard.setRepeatEvents(false);
     }
 
     @Override

--- a/src/main/java/li/cil/tis3d/client/gui/TerminalModuleGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/TerminalModuleGui.java
@@ -100,13 +100,13 @@ public final class TerminalModuleGui extends Screen {
     @Override
     public void init() {
         super.init();
-        client.keyboard.enableRepeatEvents(true);
+        client.keyboard.setRepeatEvents(true);
     }
 
     @Override
     public void onClose() {
         super.onClose();
-        client.keyboard.enableRepeatEvents(false);
+        client.keyboard.setRepeatEvents(false);
     }
 
     @Override

--- a/src/main/java/li/cil/tis3d/client/init/BootstrapClient.java
+++ b/src/main/java/li/cil/tis3d/client/init/BootstrapClient.java
@@ -2,6 +2,7 @@ package li.cil.tis3d.client.init;
 
 import li.cil.tis3d.api.API;
 import li.cil.tis3d.api.ManualAPI;
+import li.cil.tis3d.api.ClientExtInitializer;
 import li.cil.tis3d.api.prefab.manual.ItemStackTabIconRenderer;
 import li.cil.tis3d.api.prefab.manual.ResourceContentProvider;
 import li.cil.tis3d.api.prefab.manual.TextureTabIconRenderer;
@@ -20,6 +21,7 @@ import li.cil.tis3d.common.block.entity.CasingBlockEntity;
 import li.cil.tis3d.common.block.entity.ControllerBlockEntity;
 import li.cil.tis3d.common.entity.InfraredPacketEntity;
 import li.cil.tis3d.common.init.Blocks;
+import li.cil.tis3d.common.init.BootstrapCommon;
 import li.cil.tis3d.common.init.Entities;
 import li.cil.tis3d.common.init.Items;
 import li.cil.tis3d.common.module.DisplayModule;
@@ -32,6 +34,7 @@ import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.event.client.ClientSpriteRegistryCallback;
 import net.fabricmc.fabric.api.event.client.ClientTickCallback;
 import net.fabricmc.fabric.api.event.client.player.ClientPickBlockGatherCallback;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.texture.SpriteAtlasTexture;
@@ -44,6 +47,7 @@ import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.Collection;
+import java.util.List;
 
 @Environment(EnvType.CLIENT)
 public final class BootstrapClient implements ClientModInitializer {
@@ -80,6 +84,13 @@ public final class BootstrapClient implements ClientModInitializer {
         ManualAPI.addTab(new ItemStackTabIconRenderer(new ItemStack(Blocks.CONTROLLER)), "tis3d.manual.blocks", "%LANGUAGE%/block/index.md");
         ManualAPI.addTab(new ItemStackTabIconRenderer(new ItemStack(findModuleItem())), "tis3d.manual.items", "%LANGUAGE%/item/index.md");
         ManualAPI.addTab(new TextureTabIconRenderer(new Identifier(API.MOD_ID, "textures/gui/manual_serial_protocols.png")), "tis3d.manual.serial_protocols", "%LANGUAGE%/serial_protocols.md");
+
+        // Initialize extensions.
+        final String fullEntrypoint = BootstrapCommon.extensionEntrypoint("client");
+        final List<ClientExtInitializer> extensions = FabricLoader.getInstance().getEntrypoints(fullEntrypoint, ClientExtInitializer.class);
+        for (ClientExtInitializer initializer : extensions) {
+            initializer.onInitializeClient();
+        }
     }
 
     private static Item findModuleItem() {

--- a/src/main/java/li/cil/tis3d/client/render/font/FontRenderer.java
+++ b/src/main/java/li/cil/tis3d/client/render/font/FontRenderer.java
@@ -2,6 +2,9 @@ package li.cil.tis3d.client.render.font;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
 
 /**
  * Base interface for font renderers.
@@ -25,6 +28,12 @@ public interface FontRenderer {
      * @param maxChars the maximum number of characters to render.
      */
     void drawString(final CharSequence value, final int maxChars);
+
+    public void drawString(final MatrixStack.Entry matrices, final VertexConsumer vc,
+                           final int light, final int overlay, final int color,
+                           final CharSequence value, final int maxChars);
+
+    public VertexConsumer chooseVertexConsumer(final VertexConsumerProvider vcp);
 
     /**
      * Get the width of the characters drawn with the font renderer, in pixels.

--- a/src/main/java/li/cil/tis3d/common/api/FontRendererAPIImpl.java
+++ b/src/main/java/li/cil/tis3d/common/api/FontRendererAPIImpl.java
@@ -1,9 +1,14 @@
 package li.cil.tis3d.common.api;
 
+import li.cil.tis3d.api.API;
 import li.cil.tis3d.api.detail.FontRendererAPI;
 import li.cil.tis3d.client.render.font.SmallFontRenderer;
+import li.cil.tis3d.client.render.font.NormalFontRenderer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
 
 /**
  * Provide access to our tiny mono-space font.
@@ -18,6 +23,38 @@ public final class FontRendererAPIImpl implements FontRendererAPI {
     @Override
     public void drawString(final String string, final int maxChars) {
         SmallFontRenderer.INSTANCE.drawString(string, maxChars);
+    }
+
+    @Override
+    public void drawString(final API.Font font, final MatrixStack.Entry matrices, final VertexConsumer vc,
+                           final int light, final int overlay, final int color,
+                           final CharSequence value, final int maxChars) {
+        switch (font) {
+        case SmallFont:
+            SmallFontRenderer.INSTANCE.drawString(matrices, vc, light, overlay, color, value, maxChars);
+            break;
+
+        case NormalFont:
+            NormalFontRenderer.INSTANCE.drawString(matrices, vc, light, overlay, color, value, maxChars);
+            break;
+
+        default:
+            throw new RuntimeException("Font " + font + " not implemented");
+        }
+    }
+
+    @Override
+    public VertexConsumer chooseVertexConsumer(final API.Font font, final VertexConsumerProvider vcp) {
+        switch (font) {
+        case SmallFont:
+            return SmallFontRenderer.INSTANCE.chooseVertexConsumer(vcp);
+
+        case NormalFont:
+            return NormalFontRenderer.INSTANCE.chooseVertexConsumer(vcp);
+
+        default:
+            throw new RuntimeException("Font " + font + " not implemented");
+        }
     }
 
     @Override

--- a/src/main/java/li/cil/tis3d/common/entity/InfraredPacketEntity.java
+++ b/src/main/java/li/cil/tis3d/common/entity/InfraredPacketEntity.java
@@ -329,7 +329,7 @@ public final class InfraredPacketEntity extends Entity implements InfraredPacket
         EntityHitResult entityHit = null;
         double bestSqrDistance = Double.POSITIVE_INFINITY;
 
-        final List<Entity> collisions = world.getEntities(this, getBoundingBox().stretch(getVelocity()), EntityPredicates.EXCEPT_SPECTATOR);
+        final List<Entity> collisions = world.getOtherEntities(this, getBoundingBox().stretch(getVelocity()), EntityPredicates.EXCEPT_SPECTATOR);
         for (final Entity entity : collisions) {
             if (entity.collides()) {
                 final Box entityBounds = entity.getBoundingBox();

--- a/src/main/java/li/cil/tis3d/common/init/BootstrapCommon.java
+++ b/src/main/java/li/cil/tis3d/common/init/BootstrapCommon.java
@@ -1,6 +1,7 @@
 package li.cil.tis3d.common.init;
 
 import li.cil.tis3d.api.API;
+import li.cil.tis3d.api.ExtInitializer;
 import li.cil.tis3d.api.ManualAPI;
 import li.cil.tis3d.api.ModuleAPI;
 import li.cil.tis3d.client.manual.provider.GameRegistryPathProvider;
@@ -18,6 +19,7 @@ import net.fabricmc.fabric.api.event.server.ServerTickCallback;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.File;
+import java.util.List;
 
 @SuppressWarnings("unused")
 public final class BootstrapCommon implements ModInitializer {
@@ -78,5 +80,16 @@ public final class BootstrapCommon implements ModInitializer {
 
         // Mod integration.
         Integration.init();
+
+        // Initialize extensions.
+        final String fullEntrypoint =  extensionEntrypoint("main");
+        final List<ExtInitializer> extensions = FabricLoader.getInstance().getEntrypoints(fullEntrypoint, ExtInitializer.class);
+        for (ExtInitializer initializer : extensions) {
+            initializer.onInitialize();
+        }
+    }
+
+    public static String extensionEntrypoint(final String entrypoint) {
+        return API.MOD_ID + ":" + entrypoint;
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,8 +31,8 @@
         ]
     },
     "depends": {
-        "minecraft": ">=1.16-rc2",
-        "fabricloader": ">=0.4.1",
+        "minecraft": ">=1.16.2-beta.1",
+        "fabricloader": ">=0.9.0",
         "fabric": ">=0.2.7"
     },
     "mixins": [


### PR DESCRIPTION
*I'm leaving this as a draft PR for now, since it's more for discussion and not meant to be merged in the current state*

Corresponding sample extension: https://github.com/Sturmlilie/TIS-3D-Additions

The impulse for thinking about this came when I tried to write a simple "sample extension mod" that would make use of the public font API to prove that it works as intended. I discovered that from my understanding of the code, I could actually not make this work. My reasoning: The intended static entrypoints for registering anything (modules/manual pages/etc) have the following form:

```java
public static void addProvider(final ModuleProvider provider) {
    if (API.moduleAPI != null) {
        API.moduleAPI.addProvider(provider);
    }
}
```

The order in which mods in fabric are initialized is completely undefined. So if I write an extension that wants to register a module provider and calls this function, whether it actually ends up registered, or just ignored because TIS-3D happened to be initialized later, is a matter of luck.

A solution to this was pointed out to me on Discord: In fabric, you can define arbitrary entrypoints in `fabric.mod.json`. 99% of mods will just define the standard `main` (and possibly `client`/`server`), which are called by the fabric loader, at a reasonable time (I don't actually now when, but things like registries are assumed to be available). The initialization step looks like this:  
loader(minecraft) -> mod

I'm going to propose to use this same method to initialize any extension mods that want to register additional TIS-3D content:  
TIS-3D -> extension

Fabric's loader has a very flexible API; we can query a list of all entrypoints declared under a specific string id; for my mockup, I used `tis3d:main` for the common init code and `tis3d:client` for the client-side only init code, in order to mirror the loader convention.

In practice, it looks like this: TIS-3D defines `ExtInitializer` and `ClientExtInitializer` interfaces (we need both so manual pages don't get registered on servers) that mirror the mod initializer ones. Mods wishing to extend TIS-3D implement these and then declare them in their `fabric.mod.json`, like so (taken from my sample extension):  
```json
"entrypoints": {
    "tis3d:main": [
      "ancurio.tis3dadd.common.Init"
    ],
    "tis3d:client": [
      "ancurio.tis3dadd.client.ClientInit"
    ]
  },
```

During TIS-3D init, after every API has been setup, we can ask the loader, "give us a list of all entrypoints that have been specified like this, under the following string id (`tis3d:main/client`)", and simply invoke them. The extension init code can thus completely rely on our API being fully setup with zero guessing involved:  

*In TIS-3D bootstrap functions:*
```java
// Setup all API singletons
// [...]
// Init extensions
final List<ExtInitializer> extensions = FabricLoader.getInstance().getEntrypoints("tis3d:main", ExtInitializer.class);
for (ExtInitializer initializer : extensions) {
    initializer.onInitialize();
}
```

*In any extension mods:*
```java
public class Init implements ExtInitializer {
	@Override
	public void onInitialize() {
		// Do stuff with API here, register module providers etc.
	}
}
```

An interesting side effect of this is that, unless TIS-3D is present, no present extension mod will be initialized (since it doesn't define a toplevel `main` entrypoint, the loader ignores it). In fact, this pattern looks a lot like one is writing a mod for TIS-3D and not minecraft itself.

Note that we are completely free to define how the `ExtInitializer` type interfaces look like; I first tested with passing a simple string along and it worked just as well. My proposal though is to not pass anything along, because the convention in Minecraft is already to use global registry-like singletons; an extension would simply use `API.moduleAPI.addProvider(...)` directly, but it's also not necessary.

Picking up the conversation from before:

> So the main gain would be to get rid of the statics and null checks, yes? And I guess the most basic conversion would be having a 'main' API interface with getters for what are now fields in the API class [1], an implementation of which gets passed to [Client]ExtensionInitializer.onInitialize? And then it's the mods' responsibility to keep a reference of that around for future communication?

The main gain really would be that extension mods work at all; removing the null checks can be done but doesn't have to. What's important is that the null checks never return early, if they exist. How the API should be accessed now that it is guaranteed to be initialized is a separate topic where I at most will make suggestions. For example, I think getters might be overblown as the static fields of `API` are already interfaces whose implementation can be changed anytime. Also, passing interfaces to initializers is overkill IMO due to the registry convention I touched on above. Therefore, no need to split up initializer classes based on which API interface they interact with.

Edit: I wrote this, but in the process of creating my own mod, realized that passing along the API instead of having it exposed via static did make sense after all; it conveys a much stronger message of "you **can** use this now, it's fully setup, and you also shouldn't ever be able to use this **before your own init is called**." In fact, in my own mod, I store the passed API reference, and later check that for null to determine whether the API-providing mod is present at runtime.

> [1] I feel splitting it up into an initializer per sub-api could be annoying when you need more than one? More flexible in the long run, of course, but not sure that's needed here.

Splitting per sub-api would be overkill, I think the split based on common and client-side is more than enough.

> What's the initialization order here then; would mods have to define themselves as being a dependency of TIS-3D for them to be initialized before the extension initialization code gets run? Would Fabric do that automatically because it knows what other mod the interface they're implement is coming from? Would Fabric run the initialization of the mods that declare an implementation of the extension interfaces at the time those are retrieved if that hasn't happened yet? Something else?

I think extensions should still declare a static dependency on TIS-3D in their mod.json, simply for the reason so that users don't wonder why nothing is loaded if they accidentally only put the extension but not TIS-3D into the mod folder (however it wouldn't naturally lead to crashes or even state corruption). The order is directly defined by us, as I've hopefully shown above: We query the extension initializers in our own code from the loader, we directly invoke them at any point we want. The loader itself doesn't care about any entrypoints that aren't `main`/`client`/`server`.

Edit: This comment refers to extension mods which do nothing but add additional TIS-3D content. A mod merely wishing to add some form of intermod compat would not declare such a hard dependency.