### PR TITLE
Port to fabric 1.16-pre2, RFC pass

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,8 +1,8 @@
-minecraft.simpleversion=1.15.2
-minecraft.version=com.mojang:minecraft:1.15.2
-fabric.mappings=net.fabricmc:yarn:1.15.2+build.15:v2
-fabric.loader=net.fabricmc:fabric-loader:0.8.2+build.194
-fabric.api=net.fabricmc.fabric-api:fabric-api:0.5.1+build.294-1.15
+minecraft.simpleversion=1.16-pre2
+minecraft.version=com.mojang:minecraft:1.16-pre2
+fabric.mappings=net.fabricmc:yarn:1.16-pre2+build.29:v2
+fabric.loader=net.fabricmc:fabric-loader:0.8.7+build.201
+fabric.api=net.fabricmc.fabric-api:fabric-api:0.11.7+build.356-1.16
 
 mod.name=TIS-3D
 mod.group=li.cil.tis3d

--- a/src/main/java/li/cil/tis3d/api/util/RenderUtil.java
+++ b/src/main/java/li/cil/tis3d/api/util/RenderUtil.java
@@ -9,11 +9,11 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.*;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
-import net.minecraft.client.util.math.Matrix3f;
-import net.minecraft.client.util.math.Matrix4f;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Matrix3f;
+import net.minecraft.util.math.Matrix4f;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 

--- a/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
@@ -98,7 +98,7 @@ public final class CodeBookGui extends Screen {
             rebuildLines();
         }));
 
-        minecraft.keyboard.enableRepeatEvents(true);
+        client.keyboard.enableRepeatEvents(true);
     }
 
     @Override
@@ -113,20 +113,20 @@ public final class CodeBookGui extends Screen {
         data.writeToNBT(nbt);
         Network.INSTANCE.sendToServer(new CodeBookDataMessage(nbt, hand));
 
-        minecraft.keyboard.enableRepeatEvents(false);
+        client.keyboard.enableRepeatEvents(false);
     }
 
-    @Override
+    //~ @Override
     public void render(final int mouseX, final int mouseY, final float partialTicks) {
         if (player.removed || !Items.isBookCode(player.getStackInHand(hand))) {
-            MinecraftClient.getInstance().openScreen(null);
+            client.openScreen(null);
             return;
         }
 
         // Background.
         GlStateManager.color4f(1, 1, 1, 1);
-        MinecraftClient.getInstance().getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
-        blit(guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
+        client.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
+        //~ blit(guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
 
         // Check page change button availability.
         buttonPreviousPage.visible = data.getSelectedPage() > 0 && data.getPageCount() > 0;
@@ -134,14 +134,14 @@ public final class CodeBookGui extends Screen {
             (data.getSelectedPage() == data.getPageCount() - 1 && isCurrentProgramNonEmpty());
         buttonDeletePage.visible = data.getPageCount() > 1 || isCurrentProgramNonEmpty();
 
-        super.render(mouseX, mouseY, partialTicks);
+        //~ super.render(mouseX, mouseY, partialTicks);
 
         // Draw current program.
         drawProgram(mouseX, mouseY);
 
         // Draw page number.
         final String pageInfo = String.format("%d/%d", data.getSelectedPage() + 1, data.getPageCount());
-        getTextRenderer().draw(pageInfo, (float)(guiX + PAGE_NUMBER_X - getTextRenderer().getStringWidth(pageInfo) / 2), guiY + PAGE_NUMBER_Y, COLOR_CODE);
+        //~ getTextRenderer().draw(pageInfo, (float)(guiX + PAGE_NUMBER_X - getTextRenderer().getWidth(pageInfo) / 2), guiY + PAGE_NUMBER_Y, COLOR_CODE);
     }
 
     @Override
@@ -312,16 +312,16 @@ public final class CodeBookGui extends Screen {
                 selectionStart = 0;
                 selectionEnd = positionToIndex(Integer.MAX_VALUE, Integer.MAX_VALUE);
             } else if (keyCode == GLFW.GLFW_KEY_C) {
-                MinecraftClient.getInstance().keyboard.setClipboard(selectionToString());
+                client.keyboard.setClipboard(selectionToString());
             } else if (keyCode == GLFW.GLFW_KEY_X) {
-                MinecraftClient.getInstance().keyboard.setClipboard(selectionToString());
+                client.keyboard.setClipboard(selectionToString());
                 deleteSelection();
 
                 recompile();
             } else if (keyCode == GLFW.GLFW_KEY_V) {
                 deleteSelection();
 
-                final String[] pastedLines = Constants.PATTERN_LINES.split(MinecraftClient.getInstance().keyboard.getClipboard());
+                final String[] pastedLines = Constants.PATTERN_LINES.split(client.keyboard.getClipboard());
                 if (!isValidPaste(pastedLines)) {
                     return true;
                 }
@@ -385,7 +385,7 @@ public final class CodeBookGui extends Screen {
     // --------------------------------------------------------------------- //
 
     private TextRenderer getTextRenderer() {
-        return font;
+        return textRenderer;
     }
 
     private int getSelectionStart() {
@@ -437,7 +437,7 @@ public final class CodeBookGui extends Screen {
     }
 
     private int columnToX(final int line, final int column) {
-        return guiX + CODE_POS_X + getTextRenderer().getStringWidth(lines.get(line).substring(0, Math.min(column, lines.get(line).length())));
+        return guiX + CODE_POS_X + getTextRenderer().getWidth(lines.get(line).substring(0, Math.min(column, lines.get(line).length())));
     }
 
     private int positionToIndex(final int line, final int column) {
@@ -592,20 +592,20 @@ public final class CodeBookGui extends Screen {
                 final int selected = Math.min(line.length() - prefix, getSelectionEnd() - (position + prefix));
 
                 final String prefixText = line.substring(0, prefix);
-                getTextRenderer().draw(prefixText, currX, lineY, COLOR_CODE);
-                currX += getTextRenderer().getStringWidth(prefixText);
+                //~ getTextRenderer().draw(prefixText, currX, lineY, COLOR_CODE);
+                currX += getTextRenderer().getWidth(prefixText);
 
                 final String selectedText = line.substring(prefix, prefix + selected);
-                final int selectedWidth = getTextRenderer().getStringWidth(selectedText);
-                fill(currX - 1, lineY - 1, currX + selectedWidth, lineY + getTextRenderer().fontHeight - 1, COLOR_SELECTION);
-                getTextRenderer().draw(selectedText, currX, lineY, COLOR_CODE_SELECTED);
+                final int selectedWidth = getTextRenderer().getWidth(selectedText);
+                //~ fill(currX - 1, lineY - 1, currX + selectedWidth, lineY + getTextRenderer().fontHeight - 1, COLOR_SELECTION);
+                //~ getTextRenderer().draw(selectedText, currX, lineY, COLOR_CODE_SELECTED);
                 currX += selectedWidth;
 
                 final String postfixString = line.substring(prefix + selected);
-                getTextRenderer().draw(postfixString, currX, lineY, COLOR_CODE);
+                //~ getTextRenderer().draw(postfixString, currX, lineY, COLOR_CODE);
             } else {
                 // No selection here, just draw the line. Get it? "draw the line"?
-                getTextRenderer().draw(line.toString(), lineX, lineY, COLOR_CODE);
+                //~ getTextRenderer().draw(line.toString(), lineX, lineY, COLOR_CODE);
             }
 
             position += line.length() + 1;
@@ -631,9 +631,9 @@ public final class CodeBookGui extends Screen {
                 rawEndX = columnToX(localLineNumber, exception.getEnd());
             }
             final int startY = guiY + CODE_POS_Y + localLineNumber * getTextRenderer().fontHeight - 1;
-            final int endX = Math.max(rawEndX, startX + getTextRenderer().getStringWidth(" "));
+            final int endX = Math.max(rawEndX, startX + getTextRenderer().getWidth(" "));
 
-            fill(startX - 1, startY + getTextRenderer().fontHeight - 1, endX, startY + getTextRenderer().fontHeight, 0xFFFF3333);
+            //~ fill(startX - 1, startY + getTextRenderer().fontHeight - 1, endX, startY + getTextRenderer().fontHeight, 0xFFFF3333);
 
             // Draw selection position in text.
             drawTextCursor();
@@ -648,7 +648,7 @@ public final class CodeBookGui extends Screen {
                 }
                 tooltip.addAll(Arrays.asList(Constants.PATTERN_LINES.split(I18n.translate(exception.getMessage())))
                 );
-                renderTooltip(tooltip, mouseX, mouseY);
+                //~ renderTooltip(tooltip, mouseX, mouseY);
                 GlStateManager.disableLighting();
             }
         } else {
@@ -662,10 +662,10 @@ public final class CodeBookGui extends Screen {
             final int line = indexToLine(selectionEnd);
             final int column = indexToColumn(selectionEnd);
             final StringBuilder sb = lines.get(line);
-            final int x = guiX + CODE_POS_X + getTextRenderer().getStringWidth(sb.substring(0, column)) - 1;
+            final int x = guiX + CODE_POS_X + getTextRenderer().getWidth(sb.substring(0, column)) - 1;
             final int y = guiY + CODE_POS_Y + line * getTextRenderer().fontHeight - 1;
-            fill(x + 1, y + 1, x + 2 + 1, y + getTextRenderer().fontHeight + 1, 0xCC333333);
-            fill(x, y, x + 2, y + getTextRenderer().fontHeight, COLOR_CODE_SELECTED);
+            //~ fill(x + 1, y + 1, x + 2 + 1, y + getTextRenderer().fontHeight + 1, 0xCC333333);
+            //~ fill(x, y, x + 2, y + getTextRenderer().fontHeight, COLOR_CODE_SELECTED);
         }
     }
 
@@ -685,11 +685,11 @@ public final class CodeBookGui extends Screen {
         private final PageChangeType type;
 
         ButtonChangePage(final int x, final int y, final PageChangeType type, final PressAction action) {
-            super(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, "", action);
+            super(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, LiteralText.EMPTY, action);
             this.type = type;
         }
 
-        @Override
+        //~ @Override
         public void render(final int mouseX, final int mouseY, final float partialTicks) {
             if (!visible) {
                 return;
@@ -697,10 +697,10 @@ public final class CodeBookGui extends Screen {
 
             final boolean isHovered = mouseX >= x && mouseY >= y && mouseX < x + width && mouseY < y + height;
             GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-            minecraft.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
+            client.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
             final int offsetX = isHovered ? BUTTON_WIDTH : 0;
             final int offsetY = type == PageChangeType.Previous ? BUTTON_HEIGHT : 0;
-            blit(x, y, TEXTURE_X + offsetX, TEXTURE_Y + offsetY, BUTTON_WIDTH, BUTTON_HEIGHT);
+            //~ blit(x, y, TEXTURE_X + offsetX, TEXTURE_Y + offsetY, BUTTON_WIDTH, BUTTON_HEIGHT);
         }
     }
 
@@ -711,10 +711,10 @@ public final class CodeBookGui extends Screen {
         private static final int BUTTON_HEIGHT = 14;
 
         ButtonDeletePage(final int x, final int y, final PressAction action) {
-            super(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, "", action);
+            super(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, LiteralText.EMPTY, action);
         }
 
-        @Override
+        //~ @Override
         public void render(final int mouseX, final int mouseY, final float partialTicks) {
             if (!visible) {
                 return;
@@ -722,9 +722,9 @@ public final class CodeBookGui extends Screen {
 
             final boolean isHovered = mouseX >= x && mouseY >= y && mouseX < x + width && mouseY < y + height;
             GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-            minecraft.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
+            client.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
             final int offsetX = isHovered ? BUTTON_WIDTH : 0;
-            blit(x, y, TEXTURE_X + offsetX, TEXTURE_Y, BUTTON_WIDTH, BUTTON_HEIGHT);
+            //~ blit(x, y, TEXTURE_X + offsetX, TEXTURE_Y, BUTTON_WIDTH, BUTTON_HEIGHT);
         }
     }
 }

--- a/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
@@ -11,6 +11,7 @@ import li.cil.tis3d.common.module.execution.compiler.Compiler;
 import li.cil.tis3d.common.module.execution.compiler.ParseException;
 import li.cil.tis3d.common.network.Network;
 import li.cil.tis3d.common.network.message.CodeBookDataMessage;
+import li.cil.tis3d.util.FontRendererUtils;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -19,9 +20,12 @@ import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.resource.language.I18n;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.StringRenderable;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Hand;
 import org.lwjgl.glfw.GLFW;
 
@@ -116,8 +120,8 @@ public final class CodeBookGui extends Screen {
         client.keyboard.enableRepeatEvents(false);
     }
 
-    //~ @Override
-    public void render(final int mouseX, final int mouseY, final float partialTicks) {
+    @Override
+    public void render(final MatrixStack matrices, final int mouseX, final int mouseY, final float partialTicks) {
         if (player.removed || !Items.isBookCode(player.getStackInHand(hand))) {
             client.openScreen(null);
             return;
@@ -126,7 +130,7 @@ public final class CodeBookGui extends Screen {
         // Background.
         GlStateManager.color4f(1, 1, 1, 1);
         client.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
-        //~ blit(guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
+        drawTexture(matrices, guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
 
         // Check page change button availability.
         buttonPreviousPage.visible = data.getSelectedPage() > 0 && data.getPageCount() > 0;
@@ -134,14 +138,14 @@ public final class CodeBookGui extends Screen {
             (data.getSelectedPage() == data.getPageCount() - 1 && isCurrentProgramNonEmpty());
         buttonDeletePage.visible = data.getPageCount() > 1 || isCurrentProgramNonEmpty();
 
-        //~ super.render(mouseX, mouseY, partialTicks);
+        super.render(matrices, mouseX, mouseY, partialTicks);
 
         // Draw current program.
-        drawProgram(mouseX, mouseY);
+        drawProgram(matrices, mouseX, mouseY);
 
         // Draw page number.
         final String pageInfo = String.format("%d/%d", data.getSelectedPage() + 1, data.getPageCount());
-        //~ getTextRenderer().draw(pageInfo, (float)(guiX + PAGE_NUMBER_X - getTextRenderer().getWidth(pageInfo) / 2), guiY + PAGE_NUMBER_Y, COLOR_CODE);
+        getTextRenderer().draw(matrices, pageInfo, (float)(guiX + PAGE_NUMBER_X - getTextRenderer().getWidth(pageInfo) / 2), guiY + PAGE_NUMBER_Y, COLOR_CODE);
     }
 
     @Override
@@ -575,7 +579,7 @@ public final class CodeBookGui extends Screen {
         recompile();
     }
 
-    private void drawProgram(final int mouseX, final int mouseY) {
+    private void drawProgram(final MatrixStack matrices, final int mouseX, final int mouseY) {
         int position = 0;
         for (int lineNumber = 0; lineNumber < lines.size(); lineNumber++) {
             final StringBuilder line = lines.get(lineNumber);
@@ -592,20 +596,20 @@ public final class CodeBookGui extends Screen {
                 final int selected = Math.min(line.length() - prefix, getSelectionEnd() - (position + prefix));
 
                 final String prefixText = line.substring(0, prefix);
-                //~ getTextRenderer().draw(prefixText, currX, lineY, COLOR_CODE);
+                getTextRenderer().draw(matrices, prefixText, currX, lineY, COLOR_CODE);
                 currX += getTextRenderer().getWidth(prefixText);
 
                 final String selectedText = line.substring(prefix, prefix + selected);
                 final int selectedWidth = getTextRenderer().getWidth(selectedText);
-                //~ fill(currX - 1, lineY - 1, currX + selectedWidth, lineY + getTextRenderer().fontHeight - 1, COLOR_SELECTION);
-                //~ getTextRenderer().draw(selectedText, currX, lineY, COLOR_CODE_SELECTED);
+                fill(matrices, currX - 1, lineY - 1, currX + selectedWidth, lineY + getTextRenderer().fontHeight - 1, COLOR_SELECTION);
+                getTextRenderer().draw(matrices, selectedText, currX, lineY, COLOR_CODE_SELECTED);
                 currX += selectedWidth;
 
                 final String postfixString = line.substring(prefix + selected);
-                //~ getTextRenderer().draw(postfixString, currX, lineY, COLOR_CODE);
+                getTextRenderer().draw(matrices, postfixString, currX, lineY, COLOR_CODE);
             } else {
                 // No selection here, just draw the line. Get it? "draw the line"?
-                //~ getTextRenderer().draw(line.toString(), lineX, lineY, COLOR_CODE);
+                getTextRenderer().draw(matrices, line.toString(), lineX, lineY, COLOR_CODE);
             }
 
             position += line.length() + 1;
@@ -633,39 +637,40 @@ public final class CodeBookGui extends Screen {
             final int startY = guiY + CODE_POS_Y + localLineNumber * getTextRenderer().fontHeight - 1;
             final int endX = Math.max(rawEndX, startX + getTextRenderer().getWidth(" "));
 
-            //~ fill(startX - 1, startY + getTextRenderer().fontHeight - 1, endX, startY + getTextRenderer().fontHeight, 0xFFFF3333);
+            fill(matrices, startX - 1, startY + getTextRenderer().fontHeight - 1, endX, startY + getTextRenderer().fontHeight, 0xFFFF3333);
 
             // Draw selection position in text.
-            drawTextCursor();
+            drawTextCursor(matrices);
 
             // Part two of error handling, draw tooltip, *on top* of blinking cursor.
             if (mouseX >= startX && mouseX <= endX && mouseY >= startY && mouseY <= startY + getTextRenderer().fontHeight) {
-                final List<String> tooltip = new ArrayList<>();
+                final List<StringRenderable> tooltip = new ArrayList<>();
                 if (isErrorOnPreviousPage) {
-                    tooltip.add(I18n.translate(Constants.MESSAGE_ERROR_ON_PREVIOUS_PAGE));
+                    tooltip.add(new TranslatableText(Constants.MESSAGE_ERROR_ON_PREVIOUS_PAGE));
                 } else if (isErrorOnNextPage) {
-                    tooltip.add(I18n.translate(Constants.MESSAGE_ERROR_ON_NEXT_PAGE));
+                    tooltip.add(new TranslatableText(Constants.MESSAGE_ERROR_ON_NEXT_PAGE));
                 }
-                tooltip.addAll(Arrays.asList(Constants.PATTERN_LINES.split(I18n.translate(exception.getMessage())))
-                );
-                //~ renderTooltip(tooltip, mouseX, mouseY);
+                final String translatedException = I18n.translate(exception.getMessage());
+                final List<String> lines = Arrays.asList(Constants.PATTERN_LINES.split(translatedException));
+                tooltip.addAll(lines.stream().map(StringRenderable::plain).collect(Collectors.toList()));
+                renderTooltip(matrices, tooltip, mouseX, mouseY);
                 GlStateManager.disableLighting();
             }
         } else {
             // Draw selection position in text.
-            drawTextCursor();
+            drawTextCursor(matrices);
         }
     }
 
-    private void drawTextCursor() {
+    private void drawTextCursor(final MatrixStack matrices) {
         if (System.currentTimeMillis() % 800 <= 400) {
             final int line = indexToLine(selectionEnd);
             final int column = indexToColumn(selectionEnd);
             final StringBuilder sb = lines.get(line);
             final int x = guiX + CODE_POS_X + getTextRenderer().getWidth(sb.substring(0, column)) - 1;
             final int y = guiY + CODE_POS_Y + line * getTextRenderer().fontHeight - 1;
-            //~ fill(x + 1, y + 1, x + 2 + 1, y + getTextRenderer().fontHeight + 1, 0xCC333333);
-            //~ fill(x, y, x + 2, y + getTextRenderer().fontHeight, COLOR_CODE_SELECTED);
+            fill(matrices, x + 1, y + 1, x + 2 + 1, y + getTextRenderer().fontHeight + 1, 0xCC333333);
+            fill(matrices, x, y, x + 2, y + getTextRenderer().fontHeight, COLOR_CODE_SELECTED);
         }
     }
 
@@ -689,8 +694,8 @@ public final class CodeBookGui extends Screen {
             this.type = type;
         }
 
-        //~ @Override
-        public void render(final int mouseX, final int mouseY, final float partialTicks) {
+        @Override
+        public void render(final MatrixStack matrices, final int mouseX, final int mouseY, final float partialTicks) {
             if (!visible) {
                 return;
             }
@@ -700,7 +705,7 @@ public final class CodeBookGui extends Screen {
             client.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
             final int offsetX = isHovered ? BUTTON_WIDTH : 0;
             final int offsetY = type == PageChangeType.Previous ? BUTTON_HEIGHT : 0;
-            //~ blit(x, y, TEXTURE_X + offsetX, TEXTURE_Y + offsetY, BUTTON_WIDTH, BUTTON_HEIGHT);
+            drawTexture(matrices, x, y, TEXTURE_X + offsetX, TEXTURE_Y + offsetY, BUTTON_WIDTH, BUTTON_HEIGHT);
         }
     }
 
@@ -714,8 +719,8 @@ public final class CodeBookGui extends Screen {
             super(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, LiteralText.EMPTY, action);
         }
 
-        //~ @Override
-        public void render(final int mouseX, final int mouseY, final float partialTicks) {
+        @Override
+        public void render(final MatrixStack matrices, final int mouseX, final int mouseY, final float partialTicks) {
             if (!visible) {
                 return;
             }
@@ -724,7 +729,7 @@ public final class CodeBookGui extends Screen {
             GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
             client.getTextureManager().bindTexture(Textures.LOCATION_GUI_BOOK_CODE_BACKGROUND);
             final int offsetX = isHovered ? BUTTON_WIDTH : 0;
-            //~ blit(x, y, TEXTURE_X + offsetX, TEXTURE_Y, BUTTON_WIDTH, BUTTON_HEIGHT);
+            drawTexture(matrices, x, y, TEXTURE_X + offsetX, TEXTURE_Y, BUTTON_WIDTH, BUTTON_HEIGHT);
         }
     }
 }

--- a/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
@@ -120,7 +120,7 @@ public final class ManualGui extends Screen {
             final ManualAPIImpl.Tab tab = ManualAPIImpl.getTabs().get(i);
             final ImageButton button = (ImageButton)buttons.get(i);
             GlStateManager.pushMatrix();
-            //~ GlStateManager.translatef(button.x + 30, (float)(button.y + 4 - TAB_OVERLAP / 2), getBlitOffset());
+            GlStateManager.translatef(button.x + 30, (float)(button.y + 4 - TAB_OVERLAP / 2), getZOffset());
             tab.renderer.render();
             GlStateManager.popMatrix();
         }
@@ -328,10 +328,10 @@ public final class ManualGui extends Screen {
                 final Tessellator t = Tessellator.getInstance();
                 final BufferBuilder b = t.getBuffer();
                 b.begin(GL11.GL_QUADS, VertexFormats.POSITION_TEXTURE);
-                //~ b.vertex(x0, y1, getBlitOffset()).texture(u0, v1).next();
-                //~ b.vertex(x1, y1, getBlitOffset()).texture(u1, v1).next();
-                //~ b.vertex(x1, y0, getBlitOffset()).texture(u1, v0).next();
-                //~ b.vertex(x0, y0, getBlitOffset()).texture(u0, v0).next();
+                b.vertex(x0, y1, getZOffset()).texture(u0, v1).next();
+                b.vertex(x1, y1, getZOffset()).texture(u1, v1).next();
+                b.vertex(x1, y0, getZOffset()).texture(u1, v0).next();
+                b.vertex(x0, y0, getZOffset()).texture(u0, v0).next();
                 t.draw();
             }
         }

--- a/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
@@ -313,7 +313,7 @@ public final class ManualGui extends Screen {
                 MinecraftClient.getInstance().getTextureManager().bindTexture(image);
                 GlStateManager.color4f(1, 1, 1, 1);
 
-                //~ isHovered = mouseX >= x && mouseY >= y && mouseX < x + width && mouseY < y + height;
+                hovered = mouseX >= x && mouseY >= y && mouseX < x + width && mouseY < y + height;
 
                 final int x0 = x;
                 final int x1 = x + width;

--- a/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
@@ -72,7 +72,7 @@ public final class ManualGui extends Screen {
     public void init() {
         super.init();
 
-        final Window window = MinecraftClient.getInstance().getWindow();
+        final Window window = client.getWindow();
         final ScaledResolution screenSize = new ScaledResolution(window.getScaledWidth(), window.getScaledHeight());
         final ScaledResolution guiSize = new ScaledResolution(WINDOW_WIDTH, WINDOW_HEIGHT);
         final int midX = screenSize.scaledWidth / 2;
@@ -104,14 +104,14 @@ public final class ManualGui extends Screen {
         refreshPage();
     }
 
-    @Override
+    //~ @Override
     public void render(final int mouseX, final int mouseY, final float partialTicks) {
         GlStateManager.enableBlend();
 
-        super.render(mouseX, mouseY, partialTicks);
+        //~ super.render(mouseX, mouseY, partialTicks);
 
-        minecraft.getTextureManager().bindTexture(Textures.LOCATION_GUI_MANUAL_BACKGROUND);
-        DrawableHelper.blit(guiLeft, guiTop, 0, 0, xSize, ySize, WINDOW_WIDTH, WINDOW_HEIGHT);
+        client.getTextureManager().bindTexture(Textures.LOCATION_GUI_MANUAL_BACKGROUND);
+        //~ DrawableHelper.blit(guiLeft, guiTop, 0, 0, xSize, ySize, WINDOW_WIDTH, WINDOW_HEIGHT);
 
         scrollButton.active = canScroll();
         scrollButton.hoverOverride = isDragging;
@@ -120,7 +120,7 @@ public final class ManualGui extends Screen {
             final ManualAPIImpl.Tab tab = ManualAPIImpl.getTabs().get(i);
             final ImageButton button = (ImageButton)buttons.get(i);
             GlStateManager.pushMatrix();
-            GlStateManager.translatef(button.x + 30, (float)(button.y + 4 - TAB_OVERLAP / 2), getBlitOffset());
+            //~ GlStateManager.translatef(button.x + 30, (float)(button.y + 4 - TAB_OVERLAP / 2), getBlitOffset());
             tab.renderer.render();
             GlStateManager.popMatrix();
         }
@@ -128,21 +128,21 @@ public final class ManualGui extends Screen {
         currentSegment = Document.render(document, guiLeft + 16, guiTop + 48, DOCUMENT_MAX_WIDTH, DOCUMENT_MAX_HEIGHT, offset(), getTextRenderer(), mouseX, mouseY);
 
         if (!isDragging) {
-            currentSegment.ifPresent(s -> s.tooltip().ifPresent(t -> renderTooltip(Collections.singletonList(I18n.translate(t)), mouseX, mouseY)));
+            //~ currentSegment.ifPresent(s -> s.tooltip().ifPresent(t -> renderTooltip(Collections.singletonList(I18n.translate(t)), mouseX, mouseY)));
 
             for (int i = 0; i < ManualAPIImpl.getTabs().size() && i < MAX_TABS_PER_SIDE; i++) {
                 final ManualAPIImpl.Tab tab = ManualAPIImpl.getTabs().get(i);
                 final ImageButton button = (ImageButton)buttons.get(i);
                 if (mouseX > button.x && mouseX < button.x + button.getWidth() && mouseY > button.y && mouseY < button.y + button.getHeight()) {
                     if (tab.tooltip != null) {
-                        renderTooltip(Collections.singletonList(I18n.translate(tab.tooltip)), mouseX, mouseY);
+                        //~ renderTooltip(Collections.singletonList(I18n.translate(tab.tooltip)), mouseX, mouseY);
                     }
                 }
             }
         }
 
         if (canScroll() && (isCoordinateOverScrollBar(mouseX - guiLeft, mouseY - guiTop) || isDragging)) {
-            renderTooltip(Collections.singletonList(100 * offset() / maxOffset() + "%"), guiLeft + SCROLL_POS_X + SCROLL_WIDTH, scrollButton.y + scrollButton.getHeight() + 1);
+            //~ renderTooltip(Collections.singletonList(100 * offset() / maxOffset() + "%"), guiLeft + SCROLL_POS_X + SCROLL_WIDTH, scrollButton.y + scrollButton.getHeight() + 1);
         }
     }
 
@@ -156,11 +156,11 @@ public final class ManualGui extends Screen {
 
     @Override
     public boolean keyPressed(final int code, final int scancode, final int mods) {
-        if (minecraft.options.keyJump.matchesKey(code, scancode)) {
+        if (client.options.keyJump.matchesKey(code, scancode)) {
             popPage();
             return true;
-        } else if (minecraft.options.keyInventory.matchesKey(code, scancode)) {
-            minecraft.player.closeScreen();
+        } else if (client.options.keyInventory.matchesKey(code, scancode)) {
+            client.player.closeScreen();
             return true;
         } else {
             return super.keyPressed(code, scancode, mods);
@@ -224,7 +224,7 @@ public final class ManualGui extends Screen {
     // --------------------------------------------------------------------- //
 
     private TextRenderer getTextRenderer() {
-        return font;
+        return textRenderer;
     }
 
     private boolean canScroll() {
@@ -251,7 +251,7 @@ public final class ManualGui extends Screen {
             ManualAPIImpl.popPath();
             refreshPage();
         } else {
-            minecraft.player.closeScreen();
+            client.player.closeScreen();
         }
     }
 
@@ -285,7 +285,7 @@ public final class ManualGui extends Screen {
         private int imageHeightOverride = 0;
 
         ImageButton(final int x, final int y, final int w, final int h, final Identifier image, final PressAction action) {
-            super(x, y, w, h, "", action);
+            super(x, y, w, h, LiteralText.EMPTY, action);
             this.image = image;
         }
 
@@ -307,13 +307,13 @@ public final class ManualGui extends Screen {
             return height;
         }
 
-        @Override
+        //~ @Override
         public void render(final int mouseX, final int mouseY, final float partialTicks) {
             if (visible) {
                 MinecraftClient.getInstance().getTextureManager().bindTexture(image);
                 GlStateManager.color4f(1, 1, 1, 1);
 
-                isHovered = mouseX >= x && mouseY >= y && mouseX < x + width && mouseY < y + height;
+                //~ isHovered = mouseX >= x && mouseY >= y && mouseX < x + width && mouseY < y + height;
 
                 final int x0 = x;
                 final int x1 = x + width;
@@ -328,10 +328,10 @@ public final class ManualGui extends Screen {
                 final Tessellator t = Tessellator.getInstance();
                 final BufferBuilder b = t.getBuffer();
                 b.begin(GL11.GL_QUADS, VertexFormats.POSITION_TEXTURE);
-                b.vertex(x0, y1, getBlitOffset()).texture(u0, v1).next();
-                b.vertex(x1, y1, getBlitOffset()).texture(u1, v1).next();
-                b.vertex(x1, y0, getBlitOffset()).texture(u1, v0).next();
-                b.vertex(x0, y0, getBlitOffset()).texture(u0, v0).next();
+                //~ b.vertex(x0, y1, getBlitOffset()).texture(u0, v1).next();
+                //~ b.vertex(x1, y1, getBlitOffset()).texture(u1, v1).next();
+                //~ b.vertex(x1, y0, getBlitOffset()).texture(u1, v0).next();
+                //~ b.vertex(x0, y0, getBlitOffset()).texture(u0, v0).next();
                 t.draw();
             }
         }

--- a/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
@@ -7,6 +7,7 @@ import li.cil.tis3d.client.manual.Document;
 import li.cil.tis3d.client.manual.segment.InteractiveSegment;
 import li.cil.tis3d.client.manual.segment.Segment;
 import li.cil.tis3d.common.api.ManualAPIImpl;
+import li.cil.tis3d.util.FontRendererUtils;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -19,7 +20,10 @@ import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.Window;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.StringRenderable;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import org.lwjgl.opengl.GL11;
@@ -104,14 +108,14 @@ public final class ManualGui extends Screen {
         refreshPage();
     }
 
-    //~ @Override
-    public void render(final int mouseX, final int mouseY, final float partialTicks) {
+    @Override
+    public void render(final MatrixStack matrices, final int mouseX, final int mouseY, final float partialTicks) {
         GlStateManager.enableBlend();
 
-        //~ super.render(mouseX, mouseY, partialTicks);
+        super.render(matrices, mouseX, mouseY, partialTicks);
 
         client.getTextureManager().bindTexture(Textures.LOCATION_GUI_MANUAL_BACKGROUND);
-        //~ DrawableHelper.blit(guiLeft, guiTop, 0, 0, xSize, ySize, WINDOW_WIDTH, WINDOW_HEIGHT);
+        drawTexture(matrices, guiLeft, guiTop, 0, 0, xSize, ySize, WINDOW_WIDTH, WINDOW_HEIGHT);
 
         scrollButton.active = canScroll();
         scrollButton.hoverOverride = isDragging;
@@ -128,21 +132,21 @@ public final class ManualGui extends Screen {
         currentSegment = Document.render(document, guiLeft + 16, guiTop + 48, DOCUMENT_MAX_WIDTH, DOCUMENT_MAX_HEIGHT, offset(), getTextRenderer(), mouseX, mouseY);
 
         if (!isDragging) {
-            //~ currentSegment.ifPresent(s -> s.tooltip().ifPresent(t -> renderTooltip(Collections.singletonList(I18n.translate(t)), mouseX, mouseY)));
+            currentSegment.ifPresent(s -> s.tooltip().ifPresent(t -> renderTooltip(matrices, new TranslatableText(t), mouseX, mouseY)));
 
             for (int i = 0; i < ManualAPIImpl.getTabs().size() && i < MAX_TABS_PER_SIDE; i++) {
                 final ManualAPIImpl.Tab tab = ManualAPIImpl.getTabs().get(i);
                 final ImageButton button = (ImageButton)buttons.get(i);
                 if (mouseX > button.x && mouseX < button.x + button.getWidth() && mouseY > button.y && mouseY < button.y + button.getHeight()) {
                     if (tab.tooltip != null) {
-                        //~ renderTooltip(Collections.singletonList(I18n.translate(tab.tooltip)), mouseX, mouseY);
+                        renderTooltip(matrices, new TranslatableText(tab.tooltip), mouseX, mouseY);
                     }
                 }
             }
         }
 
         if (canScroll() && (isCoordinateOverScrollBar(mouseX - guiLeft, mouseY - guiTop) || isDragging)) {
-            //~ renderTooltip(Collections.singletonList(100 * offset() / maxOffset() + "%"), guiLeft + SCROLL_POS_X + SCROLL_WIDTH, scrollButton.y + scrollButton.getHeight() + 1);
+            renderTooltip(matrices, StringRenderable.plain(100 * offset() / maxOffset() + "%"), guiLeft + SCROLL_POS_X + SCROLL_WIDTH, scrollButton.y + scrollButton.getHeight() + 1);
         }
     }
 
@@ -307,8 +311,8 @@ public final class ManualGui extends Screen {
             return height;
         }
 
-        //~ @Override
-        public void render(final int mouseX, final int mouseY, final float partialTicks) {
+        @Override
+        public void render(final MatrixStack matrices, final int mouseX, final int mouseY, final float partialTicks) {
             if (visible) {
                 MinecraftClient.getInstance().getTextureManager().bindTexture(image);
                 GlStateManager.color4f(1, 1, 1, 1);

--- a/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ManualGui.java
@@ -129,7 +129,7 @@ public final class ManualGui extends Screen {
             GlStateManager.popMatrix();
         }
 
-        currentSegment = Document.render(document, guiLeft + 16, guiTop + 48, DOCUMENT_MAX_WIDTH, DOCUMENT_MAX_HEIGHT, offset(), getTextRenderer(), mouseX, mouseY);
+        currentSegment = Document.render(matrices, document, guiLeft + 16, guiTop + 48, DOCUMENT_MAX_WIDTH, DOCUMENT_MAX_HEIGHT, offset(), getTextRenderer(), mouseX, mouseY);
 
         if (!isDragging) {
             currentSegment.ifPresent(s -> s.tooltip().ifPresent(t -> renderTooltip(matrices, new TranslatableText(t), mouseX, mouseY)));

--- a/src/main/java/li/cil/tis3d/client/gui/ReadOnlyMemoryModuleGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ReadOnlyMemoryModuleGui.java
@@ -10,6 +10,7 @@ import li.cil.tis3d.common.network.message.ReadOnlyMemoryModuleDataMessage;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Hand;
@@ -75,8 +76,8 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
         client.keyboard.enableRepeatEvents(false);
     }
 
-    //~ @Override
-    public void render(final int mouseX, final int mouseY, final float partialTicks) {
+    @Override
+    public void render(final MatrixStack matrices, final int mouseX, final int mouseY, final float partialTicks) {
         if (player.removed || !Items.isModuleReadOnlyMemory(player.getStackInHand(hand))) {
             client.openScreen(null);
             return;
@@ -85,7 +86,7 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
         // Background.
         GlStateManager.color4f(1, 1, 1, 1);
         client.getTextureManager().bindTexture(Textures.LOCATION_GUI_MEMORY);
-        //~ blit(guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
+        drawTexture(matrices, guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
 
         // Draw row and column headers.
         drawHeaders();
@@ -101,7 +102,7 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
         drawMemory();
 
         // Draw marker around currently selected memory cell.
-        drawSelectionBox();
+        drawSelectionBox(matrices);
     }
 
     @Override
@@ -292,7 +293,7 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
         GlStateManager.popMatrix();
     }
 
-    private void drawSelectionBox() {
+    private void drawSelectionBox(final MatrixStack matrices) {
         final int visibleCells = (int)(System.currentTimeMillis() - initTime) * 2;
         if (selectedCell > visibleCells) {
             return;
@@ -309,7 +310,7 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
 
         client.getTextureManager().bindTexture(Textures.LOCATION_GUI_MEMORY);
         final int vPos = (int)(client.world.getTime() % 16) * 8;
-        //~ blit(0, 0, 256 - (CELL_WIDTH + 1), vPos, 11, 8);
+        drawTexture(matrices, 0, 0, 256 - (CELL_WIDTH + 1), vPos, 11, 8);
 
         GlStateManager.popMatrix();
     }

--- a/src/main/java/li/cil/tis3d/client/gui/ReadOnlyMemoryModuleGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/ReadOnlyMemoryModuleGui.java
@@ -58,7 +58,7 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
         guiX = (width - GUI_WIDTH) / 2;
         guiY = (height - GUI_HEIGHT) / 2;
 
-        minecraft.keyboard.enableRepeatEvents(true);
+        client.keyboard.enableRepeatEvents(true);
     }
 
     @Override
@@ -72,20 +72,20 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
             Network.INSTANCE.sendToServer(new ReadOnlyMemoryModuleDataMessage(data, hand));
         }
 
-        minecraft.keyboard.enableRepeatEvents(false);
+        client.keyboard.enableRepeatEvents(false);
     }
 
-    @Override
+    //~ @Override
     public void render(final int mouseX, final int mouseY, final float partialTicks) {
         if (player.removed || !Items.isModuleReadOnlyMemory(player.getStackInHand(hand))) {
-            minecraft.openScreen(null);
+            client.openScreen(null);
             return;
         }
 
         // Background.
         GlStateManager.color4f(1, 1, 1, 1);
-        minecraft.getTextureManager().bindTexture(Textures.LOCATION_GUI_MEMORY);
-        blit(guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
+        client.getTextureManager().bindTexture(Textures.LOCATION_GUI_MEMORY);
+        //~ blit(guiX, guiY, 0, 0, GUI_WIDTH, GUI_HEIGHT);
 
         // Draw row and column headers.
         drawHeaders();
@@ -307,9 +307,9 @@ public final class ReadOnlyMemoryModuleGui extends Screen {
         GlStateManager.pushMatrix();
         GlStateManager.translatef(x, y, 0);
 
-        minecraft.getTextureManager().bindTexture(Textures.LOCATION_GUI_MEMORY);
-        final int vPos = (int)(minecraft.world.getTime() % 16) * 8;
-        blit(0, 0, 256 - (CELL_WIDTH + 1), vPos, 11, 8);
+        client.getTextureManager().bindTexture(Textures.LOCATION_GUI_MEMORY);
+        final int vPos = (int)(client.world.getTime() % 16) * 8;
+        //~ blit(0, 0, 256 - (CELL_WIDTH + 1), vPos, 11, 8);
 
         GlStateManager.popMatrix();
     }

--- a/src/main/java/li/cil/tis3d/client/gui/TerminalModuleGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/TerminalModuleGui.java
@@ -28,7 +28,7 @@ public final class TerminalModuleGui extends Screen {
         return that == module;
     }
 
-    @Override
+    //~ @Override
     public void render(final int mouseX, final int mouseY, final float partialTicks) {
         GlStateManager.disableTexture();
 
@@ -91,7 +91,7 @@ public final class TerminalModuleGui extends Screen {
         module.writeToInput(chr);
 
         if (Settings.animateTypingHand) {
-            minecraft.player.swingHand(Hand.MAIN_HAND);
+            client.player.swingHand(Hand.MAIN_HAND);
         }
         return true;
     }
@@ -99,13 +99,13 @@ public final class TerminalModuleGui extends Screen {
     @Override
     public void init() {
         super.init();
-        minecraft.keyboard.enableRepeatEvents(true);
+        client.keyboard.enableRepeatEvents(true);
     }
 
     @Override
     public void onClose() {
         super.onClose();
-        minecraft.keyboard.enableRepeatEvents(false);
+        client.keyboard.enableRepeatEvents(false);
     }
 
     @Override

--- a/src/main/java/li/cil/tis3d/client/gui/TerminalModuleGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/TerminalModuleGui.java
@@ -7,6 +7,7 @@ import li.cil.tis3d.common.module.TerminalModule;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Hand;
 import org.lwjgl.glfw.GLFW;
@@ -28,8 +29,8 @@ public final class TerminalModuleGui extends Screen {
         return that == module;
     }
 
-    //~ @Override
-    public void render(final int mouseX, final int mouseY, final float partialTicks) {
+    @Override
+    public void render(final MatrixStack matrices, final int mouseX, final int mouseY, final float partialTicks) {
         GlStateManager.disableTexture();
 
         // To be on the safe side (see manual.Document#render).

--- a/src/main/java/li/cil/tis3d/client/manual/Document.java
+++ b/src/main/java/li/cil/tis3d/client/manual/Document.java
@@ -10,6 +10,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.util.Window;
+import net.minecraft.client.util.math.MatrixStack;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
@@ -103,6 +104,7 @@ public final class Document {
      * Renders a list of segments and tooltips if a segment with a tooltip is hovered.
      * Returns the hovered interactive segment, if any.
      *
+     * @param matrices  the transformation stack.
      * @param document  the document to render.
      * @param x         the x position to render at.
      * @param y         the y position to render at.
@@ -114,7 +116,7 @@ public final class Document {
      * @param mouseY    the y position of the mouse.
      * @return the interactive segment being hovered, if any.
      */
-    public static Optional<InteractiveSegment> render(final Segment document, final int x, final int y, final int maxWidth, final int maxHeight, final int yOffset, final TextRenderer renderer, final int mouseX, final int mouseY) {
+    public static Optional<InteractiveSegment> render(final MatrixStack matrices, final Segment document, final int x, final int y, final int maxWidth, final int maxHeight, final int yOffset, final TextRenderer renderer, final int mouseX, final int mouseY) {
         final MinecraftClient mc = MinecraftClient.getInstance();
         final Window window = mc.getWindow();
 
@@ -159,7 +161,7 @@ public final class Document {
         while (segment != null) {
             final int segmentHeight = segment.nextY(indent, maxWidth, renderer);
             if (currentY + segmentHeight >= minY && currentY <= maxY) {
-                final Optional<InteractiveSegment> result = segment.render(x, currentY, indent, maxWidth, renderer, mouseX, mouseY);
+                final Optional<InteractiveSegment> result = segment.render(matrices, x, currentY, indent, maxWidth, renderer, mouseX, mouseY);
                 if (!hovered.isPresent()) {
                     hovered = result;
                 }

--- a/src/main/java/li/cil/tis3d/client/manual/segment/AbstractSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/AbstractSegment.java
@@ -3,6 +3,7 @@ package li.cil.tis3d.client.manual.segment;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -20,7 +21,7 @@ abstract class AbstractSegment implements Segment {
     }
 
     @Override
-    public Optional<InteractiveSegment> render(final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
+    public Optional<InteractiveSegment> render(final MatrixStack matrices, final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
         return Optional.empty();
     }
 

--- a/src/main/java/li/cil/tis3d/client/manual/segment/BasicTextSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/BasicTextSegment.java
@@ -117,7 +117,7 @@ abstract class BasicTextSegment extends AbstractSegment implements Segment {
     }
 
     protected int computeWrapIndent(final TextRenderer renderer) {
-        return (LISTS.contains(getRootPrefix())) ? renderer.getStringWidth(getRootPrefix()) : 0;
+        return (LISTS.contains(getRootPrefix())) ? renderer.getWidth(getRootPrefix()) : 0;
     }
 
     // ----------------------------------------------------------------------- //

--- a/src/main/java/li/cil/tis3d/client/manual/segment/BasicTextSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/BasicTextSegment.java
@@ -5,6 +5,7 @@ import li.cil.tis3d.client.manual.Document;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 
 import java.util.Set;
 

--- a/src/main/java/li/cil/tis3d/client/manual/segment/CodeSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/CodeSegment.java
@@ -5,6 +5,7 @@ import li.cil.tis3d.client.render.font.NormalFontRenderer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 
 import java.util.Optional;
 
@@ -32,7 +33,7 @@ public final class CodeSegment extends BasicTextSegment {
     }
 
     @Override
-    public Optional<InteractiveSegment> render(final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
+    public Optional<InteractiveSegment> render(final MatrixStack matrices, final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
         int currentX = x + indent;
         int currentY = y + OFFSET_Y;
         String chars = text();

--- a/src/main/java/li/cil/tis3d/client/manual/segment/LinkSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/LinkSegment.java
@@ -6,6 +6,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.LiteralText;
+import net.minecraft.util.Util;
 import java.net.URI;
 import java.util.Optional;
 
@@ -95,7 +96,7 @@ public final class LinkSegment extends TextSegment implements InteractiveSegment
             final Object instance = desktop.getMethod("getDesktop").invoke(null);
             desktop.getMethod("browse", URI.class).invoke(instance, new URI(url));
         } catch (final Throwable t) {
-            MinecraftClient.getInstance().player.sendMessage(new LiteralText(t.toString()));
+            MinecraftClient.getInstance().player.sendSystemMessage(new LiteralText(t.toString()), Util.NIL_UUID);
         }
     }
 

--- a/src/main/java/li/cil/tis3d/client/manual/segment/RenderSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/RenderSegment.java
@@ -7,6 +7,7 @@ import li.cil.tis3d.client.manual.Document;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.MathHelper;
 import org.lwjgl.opengl.GL11;
 
@@ -62,7 +63,7 @@ public final class RenderSegment extends AbstractSegment implements InteractiveS
     }
 
     @Override
-    public Optional<InteractiveSegment> render(final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
+    public Optional<InteractiveSegment> render(final MatrixStack matrices, final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
         final int width = imageWidth(maxWidth);
         final int height = imageHeight(maxWidth);
         final int xOffset = (maxWidth - width) / 2;

--- a/src/main/java/li/cil/tis3d/client/manual/segment/Segment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/Segment.java
@@ -3,6 +3,7 @@ package li.cil.tis3d.client.manual.segment;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -63,6 +64,7 @@ public interface Segment {
      * Render the segment at the specified coordinates with the specified
      * properties.
      *
+     * @param matrices the transformation stack.
      * @param x        the x position to render at.
      * @param y        the y position to render at.
      * @param indent   the current indentation.
@@ -72,7 +74,7 @@ public interface Segment {
      * @param mouseY   the y mouse position.
      * @return the hovered interactive segment, if any.
      */
-    Optional<InteractiveSegment> render(final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY);
+    Optional<InteractiveSegment> render(final MatrixStack matrices, final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY);
 
     // ----------------------------------------------------------------------- //
 

--- a/src/main/java/li/cil/tis3d/client/manual/segment/TextSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/TextSegment.java
@@ -5,6 +5,7 @@ import li.cil.tis3d.client.manual.Document;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ public class TextSegment extends BasicTextSegment {
     }
 
     @Override
-    public Optional<InteractiveSegment> render(final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
+    public Optional<InteractiveSegment> render(final MatrixStack matrices, final int x, final int y, final int indent, final int maxWidth, final TextRenderer renderer, final int mouseX, final int mouseY) {
         int currentX = x + indent;
         int currentY = y;
         String chars = text;
@@ -61,7 +62,7 @@ public class TextSegment extends BasicTextSegment {
             GlStateManager.translatef(currentX, currentY, 0);
             GlStateManager.scalef(scale, scale, scale);
             GlStateManager.translatef(-currentX, -currentY, 0);
-            //~ renderer.draw(format + part, currentX, currentY, color);
+            renderer.draw(matrices, format + part, currentX, currentY, color);
             GlStateManager.popMatrix();
             currentX = x + wrapIndent;
             currentY += lineHeight(renderer);

--- a/src/main/java/li/cil/tis3d/client/manual/segment/TextSegment.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/TextSegment.java
@@ -61,7 +61,7 @@ public class TextSegment extends BasicTextSegment {
             GlStateManager.translatef(currentX, currentY, 0);
             GlStateManager.scalef(scale, scale, scale);
             GlStateManager.translatef(-currentX, -currentY, 0);
-            renderer.draw(format + part, currentX, currentY, color);
+            //~ renderer.draw(format + part, currentX, currentY, color);
             GlStateManager.popMatrix();
             currentX = x + wrapIndent;
             currentY += lineHeight(renderer);
@@ -109,7 +109,7 @@ public class TextSegment extends BasicTextSegment {
 
     @Override
     protected int stringWidth(final String s, final TextRenderer renderer) {
-        return (int)(renderer.getStringWidth(resolvedFormat() + s) * resolvedScale());
+        return (int)(renderer.getWidth(resolvedFormat() + s) * resolvedScale());
     }
 
     // ----------------------------------------------------------------------- //

--- a/src/main/java/li/cil/tis3d/client/manual/segment/render/TextureImageRenderer.java
+++ b/src/main/java/li/cil/tis3d/client/manual/segment/render/TextureImageRenderer.java
@@ -31,7 +31,7 @@ public class TextureImageRenderer implements ImageRenderer {
             this.texture = (ImageTexture)image;
         } else {
             if (image != null && image.getGlId() != -1) {
-                TextureUtil.releaseTextureId(image.getGlId());
+                TextureUtil.deleteId(image.getGlId());
             }
             this.texture = new ImageTexture(location);
             manager.registerTexture(location, texture);
@@ -81,7 +81,7 @@ public class TextureImageRenderer implements ImageRenderer {
             try (final InputStream is = resource.getInputStream()) {
                 final NativeImage bi = NativeImage.read(is);
 
-                TextureUtil.prepareImage(this.getGlId(), bi.getWidth(), bi.getHeight());
+                TextureUtil.allocate(this.getGlId(), bi.getWidth(), bi.getHeight());
                 bi.upload(0, 0, 0, false);
 
                 width = bi.getWidth();

--- a/src/main/java/li/cil/tis3d/client/mixin/HideHudInTerminalMixin.java
+++ b/src/main/java/li/cil/tis3d/client/mixin/HideHudInTerminalMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.util.math.MatrixStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -13,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(InGameHud.class)
 public abstract class HideHudInTerminalMixin extends DrawableHelper {
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void hideHud(final float tickDelta, final CallbackInfo ci) {
+    private void hideHud(final MatrixStack matrices, final float tickDelta, final CallbackInfo ci) {
         if (MinecraftClient.getInstance().currentScreen instanceof TerminalModuleGui) {
             ci.cancel();
         }

--- a/src/main/java/li/cil/tis3d/client/render/block/entity/CasingBlockEntityRenderer.java
+++ b/src/main/java/li/cil/tis3d/client/render/block/entity/CasingBlockEntityRenderer.java
@@ -75,7 +75,7 @@ public final class CasingBlockEntityRenderer extends BlockEntityRenderer<CasingB
 
     private boolean isBackFace(final BlockPos blockPos, final Face face) {
         final Vec3d cameraPosition = dispatcher.camera.getPos();
-        final Vec3d blockCenter = new Vec3d(blockPos).add(0.5, 0.5, 0.5);
+        final Vec3d blockCenter = Vec3d.of(blockPos).add(0.5, 0.5, 0.5);
         final Vec3d faceNormal = new Vec3d(Face.toDirection(face).getUnitVector());
         final Vec3d faceCenter = blockCenter.add(faceNormal.multiply(0.5));
         final Vec3d cameraToFaceCenter = faceCenter.subtract(cameraPosition);
@@ -146,7 +146,7 @@ public final class CasingBlockEntityRenderer extends BlockEntityRenderer<CasingB
                 final BlockHitResult blockHitResult = (BlockHitResult)hitResult;
                 final BlockPos pos = blockHitResult.getBlockPos();
                 assert pos != null : "dispatcher.hitResult.getBlockPos() is null even though it was non-null in isObserverLookingAt";
-                final Vec3d uv = TransformUtil.hitToUV(face, hitResult.getPos().subtract(new Vec3d(pos)));
+                final Vec3d uv = TransformUtil.hitToUV(face, hitResult.getPos().subtract(Vec3d.of(pos)));
                 lookingAtPort = Port.fromUVQuadrant(uv);
             } else {
                 closedSprite = RenderUtil.getSprite(Textures.LOCATION_OVERLAY_CASING_PORT_CLOSED_SMALL);

--- a/src/main/java/li/cil/tis3d/client/render/block/entity/ControllerBlockEntityRenderer.java
+++ b/src/main/java/li/cil/tis3d/client/render/block/entity/ControllerBlockEntityRenderer.java
@@ -11,10 +11,10 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.resource.language.I18n;
-import net.minecraft.client.util.math.Matrix4f;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.Matrix4f;
 
 @Environment(EnvType.CLIENT)
 public final class ControllerBlockEntityRenderer extends BlockEntityRenderer<ControllerBlockEntity> {
@@ -43,7 +43,7 @@ public final class ControllerBlockEntityRenderer extends BlockEntityRenderer<Con
         final Matrix4f modMat = matrices.peek().getModel();
         final int bg = MinecraftClient.getInstance().options.getTextBackgroundColor(0.25f);
         final TextRenderer textRenderer = dispatcher.getTextRenderer();
-        final float x = -textRenderer.getStringWidth(str) / 2.0f;
+        final float x = -textRenderer.getWidth(str) / 2.0f;
         textRenderer.draw(str, x, 0, 0x20FFFFFF, false, modMat, vcp, true, bg, RenderUtil.maxLight);
         textRenderer.draw(str, x, 0, -1, false, modMat, vcp, false, 0, RenderUtil.maxLight);
 

--- a/src/main/java/li/cil/tis3d/common/block/ControllerBlock.java
+++ b/src/main/java/li/cil/tis3d/common/block/ControllerBlock.java
@@ -45,7 +45,7 @@ public final class ControllerBlock extends Block implements BlockEntityProvider 
                     }
                     final ItemStack bookManual = new ItemStack(Items.BOOK_MANUAL);
                     if (player.inventory.insertStack(bookManual)) {
-                        player.playerContainer.sendContentUpdates();
+                        player.playerScreenHandler.sendContentUpdates();
                     }
                     if (bookManual.getCount() > 0) {
                         player.dropItem(bookManual, false, false);
@@ -71,11 +71,11 @@ public final class ControllerBlock extends Block implements BlockEntityProvider 
 
     @SuppressWarnings("deprecation")
     @Override
-    public void onBlockRemoved(final BlockState state, final World world, final BlockPos pos, final BlockState newState, final boolean flag) {
+    public void onStateReplaced(final BlockState state, final World world, final BlockPos pos, final BlockState newState, final boolean flag) {
         if (state.getBlock() != newState.getBlock()) {
             world.removeBlockEntity(pos);
         }
-        super.onBlockRemoved(state, world, pos, newState, flag);
+        super.onStateReplaced(state, world, pos, newState, flag);
     }
 
     // --------------------------------------------------------------------- //

--- a/src/main/java/li/cil/tis3d/common/block/entity/AbstractComputerBlockEntity.java
+++ b/src/main/java/li/cil/tis3d/common/block/entity/AbstractComputerBlockEntity.java
@@ -8,6 +8,7 @@ import li.cil.tis3d.common.machine.PipeImpl;
 import li.cil.tis3d.util.NBTIds;
 import li.cil.tis3d.util.WorldUtils;
 import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.nbt.CompoundTag;
@@ -146,8 +147,8 @@ public abstract class AbstractComputerBlockEntity extends BlockEntity implements
     // BlockEntity
 
     @Override
-    public void fromTag(final CompoundTag nbt) {
-        super.fromTag(nbt);
+    public void fromTag(final BlockState state, final CompoundTag nbt) {
+        super.fromTag(state, nbt);
         if (nbt.contains("_client")) {
             fromClientTag(nbt);
         } else {

--- a/src/main/java/li/cil/tis3d/common/block/entity/CasingBlockEntity.java
+++ b/src/main/java/li/cil/tis3d/common/block/entity/CasingBlockEntity.java
@@ -259,7 +259,7 @@ public final class CasingBlockEntity extends AbstractComputerBlockEntity impleme
 
         // Ensure there are no modules installed between two casings.
         if (hasNeighbor(face)) {
-            InventoryUtils.drop(world, getPos(), this, face.ordinal(), getInvMaxStackAmount(), Face.toDirection(face));
+            InventoryUtils.drop(world, getPos(), this, face.ordinal(), getMaxCountPerStack(), Face.toDirection(face));
         }
 
         if (neighbor instanceof ControllerBlockEntity) {
@@ -296,7 +296,7 @@ public final class CasingBlockEntity extends AbstractComputerBlockEntity impleme
     // Inventory
 
     @Override
-    public boolean canPlayerUseInv(final PlayerEntity player) {
+    public boolean canPlayerUse(final PlayerEntity player) {
         if (world.getBlockEntity(pos) != this) {
             return false;
         }
@@ -433,7 +433,7 @@ public final class CasingBlockEntity extends AbstractComputerBlockEntity impleme
      */
     @Environment(EnvType.CLIENT)
     public void setStackAndModuleClient(final int slot, final ItemStack stack, final CompoundTag moduleData) {
-        inventory.setInvStack(slot, stack);
+        inventory.setStack(slot, stack);
         final Module module = casing.getModule(Face.VALUES[slot]);
         if (module != null) {
             module.readFromNBT(moduleData);

--- a/src/main/java/li/cil/tis3d/common/entity/InfraredPacketEntity.java
+++ b/src/main/java/li/cil/tis3d/common/entity/InfraredPacketEntity.java
@@ -183,11 +183,6 @@ public final class InfraredPacketEntity extends Entity implements InfraredPacket
     }
 
     @Override
-    public boolean checkWaterState() {
-        return false;
-    }
-
-    @Override
     public boolean canFly() {
         return false;
     }
@@ -213,7 +208,7 @@ public final class InfraredPacketEntity extends Entity implements InfraredPacket
 
     @Override
     public Vec3d getPacketPosition() {
-        return getPosVector();
+        return getPos();
     }
 
     @Override
@@ -229,7 +224,7 @@ public final class InfraredPacketEntity extends Entity implements InfraredPacket
             revive();
 
             // Apply new position.
-            final Vec3d oldPos = getPosVector();
+            final Vec3d oldPos = getPos();
             final Vec3d delta = position.subtract(oldPos);
             final double sqrDelta = delta.dotProduct(delta);
             if (sqrDelta > TRAVEL_SPEED * TRAVEL_SPEED) {
@@ -275,7 +270,7 @@ public final class InfraredPacketEntity extends Entity implements InfraredPacket
         final HitResult hitResult = checkCollision();
         if (hitResult != null) {
             // For travel distance adjustment, see below.
-            final Vec3d oldPos = getPosVector();
+            final Vec3d oldPos = getPos();
 
             switch (hitResult.getType()) {
                 case BLOCK:
@@ -291,7 +286,7 @@ public final class InfraredPacketEntity extends Entity implements InfraredPacket
             // Offset to compensate position adjustments. This way the total
             // distance the packet travels per tick stays constant, even if
             // it was moved around by a packet handler.
-            final Vec3d curPos = getPosVector();
+            final Vec3d curPos = getPos();
             final double delta = curPos.subtract(oldPos).length() / TRAVEL_SPEED;
 
             setPos(curPos.subtract(getVelocity().multiply(delta)));

--- a/src/main/java/li/cil/tis3d/common/init/Entities.java
+++ b/src/main/java/li/cil/tis3d/common/init/Entities.java
@@ -3,14 +3,14 @@ package li.cil.tis3d.common.init;
 import li.cil.tis3d.common.Constants;
 import li.cil.tis3d.common.entity.InfraredPacketEntity;
 import net.fabricmc.fabric.api.entity.FabricEntityTypeBuilder;
-import net.minecraft.entity.EntityCategory;
 import net.minecraft.entity.EntityDimensions;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnGroup;
 import net.minecraft.util.registry.Registry;
 
 public final class Entities {
     public static final EntityType<InfraredPacketEntity> INFRARED_PACKET = FabricEntityTypeBuilder.create(
-        EntityCategory.MISC, InfraredPacketEntity::new).disableSummon().size(
+        SpawnGroup.MISC, InfraredPacketEntity::new).disableSummon().size(
         new EntityDimensions(0.25F, 0.25F, true)
     ).setImmuneToFire().build();
 

--- a/src/main/java/li/cil/tis3d/common/inventory/ArrayInventory.java
+++ b/src/main/java/li/cil/tis3d/common/inventory/ArrayInventory.java
@@ -55,11 +55,11 @@ public class ArrayInventory implements Inventory {
     // Inventory
 
     @Override
-    public int getInvSize() {
+    public int size() {
         return items.length;
     }
 
-    public boolean isInvEmpty() {
+    public boolean isEmpty() {
         for (final ItemStack stack : items) {
             if (!stack.isEmpty()) {
                 return false;
@@ -70,14 +70,14 @@ public class ArrayInventory implements Inventory {
     }
 
     @Override
-    public ItemStack getInvStack(final int index) {
+    public ItemStack getStack(final int index) {
         return items[index];
     }
 
     @Override
-    public ItemStack takeInvStack(final int index, final int count) {
+    public ItemStack removeStack(final int index, final int count) {
         if (items[index].getCount() <= count) {
-            return removeInvStack(index);
+            return removeStack(index);
         } else {
             final ItemStack stack = items[index].split(count);
             assert items[index].getCount() > 0;
@@ -87,14 +87,14 @@ public class ArrayInventory implements Inventory {
     }
 
     @Override
-    public ItemStack removeInvStack(final int index) {
+    public ItemStack removeStack(final int index) {
         final ItemStack stack = items[index];
-        setInvStack(index, ItemStack.EMPTY);
+        setStack(index, ItemStack.EMPTY);
         return stack;
     }
 
     @Override
-    public void setInvStack(final int index, final ItemStack stack) {
+    public void setStack(final int index, final ItemStack stack) {
         if (items[index] == stack) {
             return;
         }
@@ -113,7 +113,7 @@ public class ArrayInventory implements Inventory {
     }
 
     @Override
-    public int getInvMaxStackAmount() {
+    public int getMaxCountPerStack() {
         return 64;
     }
 
@@ -122,7 +122,7 @@ public class ArrayInventory implements Inventory {
     }
 
     @Override
-    public boolean canPlayerUseInv(final PlayerEntity player) {
+    public boolean canPlayerUse(final PlayerEntity player) {
         return false;
     }
 

--- a/src/main/java/li/cil/tis3d/common/inventory/CasingInventory.java
+++ b/src/main/java/li/cil/tis3d/common/inventory/CasingInventory.java
@@ -54,7 +54,7 @@ public final class CasingInventory extends ArrayInventory implements SidedInvent
     // Inventory
 
     @Override
-    public int getInvMaxStackAmount() {
+    public int getMaxCountPerStack() {
         return 1;
     }
 
@@ -67,7 +67,7 @@ public final class CasingInventory extends ArrayInventory implements SidedInvent
         blockEntity.markDirty();
         if (world.isClient) {
             // Re-render on client, as module presence changes the block model.
-            world.checkBlockRerender(blockEntity.getPos(), state, newState);
+            world.scheduleBlockRerenderIfNeeded(blockEntity.getPos(), state, newState);
         }
     }
 
@@ -75,21 +75,21 @@ public final class CasingInventory extends ArrayInventory implements SidedInvent
     // SidedInventory
 
     @Override
-    public int[] getInvAvailableSlots(final Direction side) {
+    public int[] getAvailableSlots(final Direction side) {
         return new int[side.ordinal()];
     }
 
     @Override
-    public boolean canInsertInvStack(final int index, final ItemStack stack, @Nullable final Direction side) {
+    public boolean canInsert(final int index, final ItemStack stack, @Nullable final Direction side) {
         return side != null && side.ordinal() == index &&
-            getInvStack(index).isEmpty() &&
+            getStack(index).isEmpty() &&
             blockEntity.getModule(Face.fromDirection(side)) == null && // Handles virtual modules.
             canInstall(stack, Face.fromDirection(side));
     }
 
     @Override
-    public boolean canExtractInvStack(final int index, final ItemStack stack, final Direction side) {
-        return side.ordinal() == index && stack == getInvStack(index);
+    public boolean canExtract(final int index, final ItemStack stack, final Direction side) {
+        return side.ordinal() == index && stack == getStack(index);
     }
 
     private boolean canInstall(final ItemStack stack, final Face face) {
@@ -107,7 +107,7 @@ public final class CasingInventory extends ArrayInventory implements SidedInvent
     private void onItemAdded(final int index, final Port facing) {
         final World world = Objects.requireNonNull(blockEntity.getWorld());
 
-        final ItemStack stack = getInvStack(index);
+        final ItemStack stack = getStack(index);
         if (stack.isEmpty()) {
             return;
         }
@@ -153,7 +153,7 @@ public final class CasingInventory extends ArrayInventory implements SidedInvent
         blockEntity.setModule(face, null);
         if (!world.isClient) {
             if (module != null) {
-                module.onUninstalled(getInvStack(index));
+                module.onUninstalled(getStack(index));
                 module.onDisposed();
             }
 

--- a/src/main/java/li/cil/tis3d/common/inventory/InventoryProxy.java
+++ b/src/main/java/li/cil/tis3d/common/inventory/InventoryProxy.java
@@ -8,38 +8,38 @@ public interface InventoryProxy extends Inventory {
     Inventory getInventory();
 
     @Override
-    default int getInvSize() {
-        return getInventory().getInvSize();
+    default int size() {
+        return getInventory().size();
     }
 
     @Override
-    default boolean isInvEmpty() {
-        return getInventory().isInvEmpty();
+    default boolean isEmpty() {
+        return getInventory().isEmpty();
     }
 
     @Override
-    default ItemStack getInvStack(final int slot) {
-        return getInventory().getInvStack(slot);
+    default ItemStack getStack(final int slot) {
+        return getInventory().getStack(slot);
     }
 
     @Override
-    default ItemStack takeInvStack(final int slot, final int count) {
-        return getInventory().takeInvStack(slot, count);
+    default ItemStack removeStack(final int slot, final int count) {
+        return getInventory().removeStack(slot, count);
     }
 
     @Override
-    default ItemStack removeInvStack(final int slot) {
-        return getInventory().removeInvStack(slot);
+    default ItemStack removeStack(final int slot) {
+        return getInventory().removeStack(slot);
     }
 
     @Override
-    default void setInvStack(final int slot, final ItemStack stack) {
-        getInventory().setInvStack(slot, stack);
+    default void setStack(final int slot, final ItemStack stack) {
+        getInventory().setStack(slot, stack);
     }
 
     @Override
-    default int getInvMaxStackAmount() {
-        return getInventory().getInvMaxStackAmount();
+    default int getMaxCountPerStack() {
+        return getInventory().getMaxCountPerStack();
     }
 
     @Override
@@ -48,23 +48,23 @@ public interface InventoryProxy extends Inventory {
     }
 
     @Override
-    default boolean canPlayerUseInv(final PlayerEntity player) {
-        return getInventory().canPlayerUseInv(player);
+    default boolean canPlayerUse(final PlayerEntity player) {
+        return getInventory().canPlayerUse(player);
     }
 
     @Override
-    default void onInvOpen(final PlayerEntity player) {
-        getInventory().onInvOpen(player);
+    default void onOpen(final PlayerEntity player) {
+        getInventory().onOpen(player);
     }
 
     @Override
-    default void onInvClose(final PlayerEntity player) {
-        getInventory().onInvClose(player);
+    default void onClose(final PlayerEntity player) {
+        getInventory().onClose(player);
     }
 
     @Override
-    default boolean isValidInvStack(final int slot, final ItemStack stack) {
-        return getInventory().isValidInvStack(slot, stack);
+    default boolean isValid(final int slot, final ItemStack stack) {
+        return getInventory().isValid(slot, stack);
     }
 
     @Override

--- a/src/main/java/li/cil/tis3d/common/inventory/SidedInventoryProxy.java
+++ b/src/main/java/li/cil/tis3d/common/inventory/SidedInventoryProxy.java
@@ -11,17 +11,17 @@ public interface SidedInventoryProxy extends InventoryProxy, SidedInventory {
     SidedInventory getInventory();
 
     @Override
-    default int[] getInvAvailableSlots(final Direction facing) {
-        return getInventory().getInvAvailableSlots(facing);
+    default int[] getAvailableSlots(final Direction facing) {
+        return getInventory().getAvailableSlots(facing);
     }
 
     @Override
-    default boolean canInsertInvStack(final int slot, final ItemStack stack, @Nullable final Direction facing) {
-        return getInventory().canInsertInvStack(slot, stack, facing);
+    default boolean canInsert(final int slot, final ItemStack stack, @Nullable final Direction facing) {
+        return getInventory().canInsert(slot, stack, facing);
     }
 
     @Override
-    default boolean canExtractInvStack(final int slot, final ItemStack stack, final Direction facing) {
-        return getInventory().canExtractInvStack(slot, stack, facing);
+    default boolean canExtract(final int slot, final ItemStack stack, final Direction facing) {
+        return getInventory().canExtract(slot, stack, facing);
     }
 }

--- a/src/main/java/li/cil/tis3d/common/machine/CasingImpl.java
+++ b/src/main/java/li/cil/tis3d/common/machine/CasingImpl.java
@@ -241,8 +241,8 @@ public final class CasingImpl implements Casing {
      * @param nbt the data to load.
      */
     public void readFromNBT(final CompoundTag nbt) {
-        for (int index = 0; index < blockEntity.getInvSize(); index++) {
-            final ItemStack stack = blockEntity.getInvStack(index);
+        for (int index = 0; index < blockEntity.size(); index++) {
+            final ItemStack stack = blockEntity.getStack(index);
             if (stack.isEmpty()) {
                 if (modules[index] != null) {
                     modules[index].onDisposed();

--- a/src/main/java/li/cil/tis3d/common/module/DisplayModule.java
+++ b/src/main/java/li/cil/tis3d/common/module/DisplayModule.java
@@ -296,7 +296,7 @@ public final class DisplayModule extends AbstractModuleWithRotation {
         int ip = 0;
         for (int iy = 0; iy < RESOLUTION; iy++) {
             for (int ix = 0; ix < RESOLUTION; ix++, ip++) {
-                img.setPixelRgba(ix, iy, image[ip]);
+                img.setPixelColor(ix, iy, image[ip]);
             }
         }
     }

--- a/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
+++ b/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
@@ -163,7 +163,7 @@ public final class ExecutionModule extends AbstractModuleWithRotation implements
                 }
                 final ItemStack bookCode = new ItemStack(Items.BOOK_CODE);
                 if (player.inventory.insertStack(bookCode)) {
-                    player.playerContainer.sendContentUpdates();
+                    player.playerScreenHandler.sendContentUpdates();
                 }
                 if (bookCode.getCount() > 0) {
                     player.dropItem(bookCode, false, false);
@@ -324,7 +324,7 @@ public final class ExecutionModule extends AbstractModuleWithRotation implements
             Compiler.compile(code, getState());
         } catch (final ParseException e) {
             compileError = e;
-            player.addChatMessage(new TranslatableText(Constants.MESSAGE_COMPILE_ERROR, e.getLineNumber(), e.getStart(), e.getEnd()).append(new TranslatableText(e.getMessage())), false);
+            player.sendMessage(new TranslatableText(Constants.MESSAGE_COMPILE_ERROR, e.getLineNumber(), e.getStart(), e.getEnd()).append(new TranslatableText(e.getMessage())), false);
         }
     }
 

--- a/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
+++ b/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
@@ -64,12 +64,15 @@ public final class ExecutionModule extends AbstractModuleWithRotation implements
         WAIT
     }
 
-    private static final Identifier[] STATE_LOCATIONS = new Identifier[]{
-        Textures.LOCATION_OVERLAY_MODULE_EXECUTION_IDLE,
-        Textures.LOCATION_OVERLAY_MODULE_EXECUTION_ERROR,
-        Textures.LOCATION_OVERLAY_MODULE_EXECUTION_RUNNING,
-        Textures.LOCATION_OVERLAY_MODULE_EXECUTION_WAITING
-    };
+    @Environment(EnvType.CLIENT)
+    private static final class RenderData {
+        static final Identifier[] STATE_LOCATIONS = new Identifier[]{
+            Textures.LOCATION_OVERLAY_MODULE_EXECUTION_IDLE,
+            Textures.LOCATION_OVERLAY_MODULE_EXECUTION_ERROR,
+            Textures.LOCATION_OVERLAY_MODULE_EXECUTION_RUNNING,
+            Textures.LOCATION_OVERLAY_MODULE_EXECUTION_WAITING
+        };
+    }
 
     // NBT tag names.
     private static final String TAG_STATE = "state";
@@ -245,7 +248,7 @@ public final class ExecutionModule extends AbstractModuleWithRotation implements
         rotateForRendering(matrices);
 
         // Draw status texture.
-        final Sprite baseSprite = RenderUtil.getSprite(STATE_LOCATIONS[state.ordinal()]);
+        final Sprite baseSprite = RenderUtil.getSprite(RenderData.STATE_LOCATIONS[state.ordinal()]);
         final VertexConsumer vc = vcp.getBuffer(RenderLayer.getCutoutMipped());
         RenderUtil.drawQuad(baseSprite, matrices.peek(), vc, RenderUtil.maxLight, overlay);
 

--- a/src/main/java/li/cil/tis3d/common/network/Network.java
+++ b/src/main/java/li/cil/tis3d/common/network/Network.java
@@ -28,13 +28,13 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.network.Packet;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.network.packet.s2c.play.ParticleS2CPacket;
 import net.minecraft.particle.DustParticleEffect;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.PacketByteBuf;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -161,7 +161,7 @@ public final class Network {
         int sent = 0;
         for (final PlayerEntity player : world.getPlayers()) {
             if (player instanceof ServerPlayerEntity) {
-                if (player.squaredDistanceTo(new Vec3d(pos)) < rangeSq) {
+                if (player.squaredDistanceTo(Vec3d.of(pos)) < rangeSq) {
                     final ServerPlayerEntity networkedPlayer = (ServerPlayerEntity)player;
                     networkedPlayer.networkHandler.sendPacket(packet);
                     if (!networkedPlayer.networkHandler.connection.isLocal()) {
@@ -293,7 +293,8 @@ public final class Network {
             }
 
             final Position that = (Position)obj;
-            return world.dimension.getType() == that.world.dimension.getType() &&
+            //~ return world.dimension.getType() == that.world.dimension.getType() &&
+            return true &&
                 Float.compare(that.x, x) == 0 &&
                 Float.compare(that.y, y) == 0 &&
                 Float.compare(that.z, z) == 0;
@@ -302,7 +303,8 @@ public final class Network {
 
         @Override
         public int hashCode() {
-            int result = world.dimension.getType().getRawId();
+            //~ int result = world.dimension.getType().getRawId();
+            int result = 0xDEADBEEF;
             result = 31 * result + (x != +0.0f ? Float.floatToIntBits(x) : 0);
             result = 31 * result + (y != +0.0f ? Float.floatToIntBits(y) : 0);
             result = 31 * result + (z != +0.0f ? Float.floatToIntBits(z) : 0);

--- a/src/main/java/li/cil/tis3d/common/network/Network.java
+++ b/src/main/java/li/cil/tis3d/common/network/Network.java
@@ -293,8 +293,7 @@ public final class Network {
             }
 
             final Position that = (Position)obj;
-            //~ return world.dimension.getType() == that.world.dimension.getType() &&
-            return true &&
+            return world.equals(that.world) &&
                 Float.compare(that.x, x) == 0 &&
                 Float.compare(that.y, y) == 0 &&
                 Float.compare(that.z, z) == 0;
@@ -303,8 +302,7 @@ public final class Network {
 
         @Override
         public int hashCode() {
-            //~ int result = world.dimension.getType().getRawId();
-            int result = 0xDEADBEEF;
+            int result = world.hashCode();
             result = 31 * result + (x != +0.0f ? Float.floatToIntBits(x) : 0);
             result = 31 * result + (y != +0.0f ? Float.floatToIntBits(y) : 0);
             result = 31 * result + (z != +0.0f ? Float.floatToIntBits(z) : 0);

--- a/src/main/java/li/cil/tis3d/common/network/handler/AbstractMessageHandler.java
+++ b/src/main/java/li/cil/tis3d/common/network/handler/AbstractMessageHandler.java
@@ -28,45 +28,6 @@ public abstract class AbstractMessageHandler<T extends AbstractMessage> {
 
     @Nullable
     protected World getWorld(final DimensionType dimension, final PacketContext context) {
-        switch (context.getPacketEnvironment()) {
-            case CLIENT:
-                //noinspection MethodCallSideOnly Guarded by CLIENT switch case.
-                return getWorldClient(dimension, context);
-            case SERVER:
-                return getWorldServer(dimension, context);
-            default:
-                return null;
-        }
-    }
-
-    @Environment(EnvType.CLIENT)
-    @Nullable
-    private static World getWorldClient(final DimensionType dimension, final PacketContext context) {
-        final PlayerEntity player = context.getPlayer();
-        if (player == null) {
-            return null;
-        }
-
-        final World world = player.world;
-        if (world == null) {
-            return null;
-        }
-
-        //~ if (world.getDimension().getType() != dimension) {
-            //~ return null;
-        //~ }
-
-        return world;
-    }
-
-    @Nullable
-    private static World getWorldServer(final DimensionType dimension, final PacketContext context) {
-        final MinecraftServer server = context.getPlayer().getServer();
-        if (server == null) {
-            return null;
-        }
-
-        //~ return server.getWorld(dimension);
-        return null; // XXX
+        return context.getPlayer().world;
     }
 }

--- a/src/main/java/li/cil/tis3d/common/network/handler/AbstractMessageHandler.java
+++ b/src/main/java/li/cil/tis3d/common/network/handler/AbstractMessageHandler.java
@@ -52,9 +52,9 @@ public abstract class AbstractMessageHandler<T extends AbstractMessage> {
             return null;
         }
 
-        if (world.getDimension().getType() != dimension) {
-            return null;
-        }
+        //~ if (world.getDimension().getType() != dimension) {
+            //~ return null;
+        //~ }
 
         return world;
     }
@@ -66,6 +66,7 @@ public abstract class AbstractMessageHandler<T extends AbstractMessage> {
             return null;
         }
 
-        return server.getWorld(dimension);
+        //~ return server.getWorld(dimension);
+        return null; // XXX
     }
 }

--- a/src/main/java/li/cil/tis3d/common/network/handler/AbstractMessageHandlerWithDimension.java
+++ b/src/main/java/li/cil/tis3d/common/network/handler/AbstractMessageHandlerWithDimension.java
@@ -9,6 +9,6 @@ import javax.annotation.Nullable;
 public abstract class AbstractMessageHandlerWithDimension<T extends AbstractMessageWithDimension> extends AbstractMessageHandler<T> {
     @Nullable
     protected World getWorld(final T message, final PacketContext context) {
-        return getWorld(message.getDimension(), context);
+        return context.getPlayer().world;
     }
 }

--- a/src/main/java/li/cil/tis3d/common/network/message/AbstractMessageWithDimension.java
+++ b/src/main/java/li/cil/tis3d/common/network/message/AbstractMessageWithDimension.java
@@ -1,7 +1,7 @@
 package li.cil.tis3d.common.network.message;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.util.PacketByteBuf;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
 
@@ -9,7 +9,7 @@ public abstract class AbstractMessageWithDimension extends AbstractMessage {
     private DimensionType dimension;
 
     AbstractMessageWithDimension(final World world) {
-        this.dimension = world.dimension.getType();
+        //~ this.dimension = world.dimension.getType();
     }
 
     AbstractMessageWithDimension() {
@@ -27,12 +27,12 @@ public abstract class AbstractMessageWithDimension extends AbstractMessage {
     @Override
     public void fromBytes(final ByteBuf buf) {
         final PacketByteBuf buffer = new PacketByteBuf(buf);
-        dimension = DimensionType.byRawId(buffer.readVarInt());
+        //~ dimension = DimensionType.byRawId(buffer.readVarInt());
     }
 
     @Override
     public void toBytes(final ByteBuf buf) {
         final PacketByteBuf buffer = new PacketByteBuf(buf);
-        buffer.writeVarInt(dimension.getRawId());
+        //~ buffer.writeVarInt(dimension.getRawId());
     }
 }

--- a/src/main/java/li/cil/tis3d/common/network/message/AbstractMessageWithDimension.java
+++ b/src/main/java/li/cil/tis3d/common/network/message/AbstractMessageWithDimension.java
@@ -6,19 +6,11 @@ import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
 
 public abstract class AbstractMessageWithDimension extends AbstractMessage {
-    private DimensionType dimension;
 
     AbstractMessageWithDimension(final World world) {
-        //~ this.dimension = world.dimension.getType();
     }
 
     AbstractMessageWithDimension() {
-    }
-
-    // --------------------------------------------------------------------- //
-
-    public DimensionType getDimension() {
-        return dimension;
     }
 
     // --------------------------------------------------------------------- //
@@ -26,13 +18,9 @@ public abstract class AbstractMessageWithDimension extends AbstractMessage {
 
     @Override
     public void fromBytes(final ByteBuf buf) {
-        final PacketByteBuf buffer = new PacketByteBuf(buf);
-        //~ dimension = DimensionType.byRawId(buffer.readVarInt());
     }
 
     @Override
     public void toBytes(final ByteBuf buf) {
-        final PacketByteBuf buffer = new PacketByteBuf(buf);
-        //~ buffer.writeVarInt(dimension.getRawId());
     }
 }

--- a/src/main/java/li/cil/tis3d/common/network/message/AbstractMessageWithLocation.java
+++ b/src/main/java/li/cil/tis3d/common/network/message/AbstractMessageWithLocation.java
@@ -1,7 +1,7 @@
 package li.cil.tis3d.common.network.message;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.util.PacketByteBuf;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 

--- a/src/main/java/li/cil/tis3d/common/network/message/CasingInventoryMessage.java
+++ b/src/main/java/li/cil/tis3d/common/network/message/CasingInventoryMessage.java
@@ -4,8 +4,7 @@ import io.netty.buffer.ByteBuf;
 import li.cil.tis3d.api.machine.Casing;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.util.PacketByteBuf;
-
+import net.minecraft.network.PacketByteBuf;
 import javax.annotation.Nullable;
 
 public final class CasingInventoryMessage extends AbstractMessageWithLocation {

--- a/src/main/java/li/cil/tis3d/common/network/message/CodeBookDataMessage.java
+++ b/src/main/java/li/cil/tis3d/common/network/message/CodeBookDataMessage.java
@@ -2,8 +2,8 @@ package li.cil.tis3d.common.network.message;
 
 import io.netty.buffer.ByteBuf;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Hand;
-import net.minecraft.util.PacketByteBuf;
 
 public final class CodeBookDataMessage extends AbstractMessage {
     private CompoundTag nbt;

--- a/src/main/java/li/cil/tis3d/common/network/message/ReadOnlyMemoryModuleDataMessage.java
+++ b/src/main/java/li/cil/tis3d/common/network/message/ReadOnlyMemoryModuleDataMessage.java
@@ -1,8 +1,8 @@
 package li.cil.tis3d.common.network.message;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Hand;
-import net.minecraft.util.PacketByteBuf;
 
 public final class ReadOnlyMemoryModuleDataMessage extends AbstractMessage {
     private byte[] data;

--- a/src/main/java/li/cil/tis3d/util/FontRendererUtils.java
+++ b/src/main/java/li/cil/tis3d/util/FontRendererUtils.java
@@ -27,9 +27,10 @@ public final class FontRendererUtils {
      */
     public static void addStringToTooltip(final String info, final List<Text> tooltip) {
         final MinecraftClient mc = MinecraftClient.getInstance();
-        if (mc != null) {
+        //~ if (mc != null) {
+        if (false) { // XXX
             final TextRenderer fontRenderer = mc.textRenderer;
-            tooltip.addAll(fontRenderer.wrapStringToWidthAsList(info, Constants.MAX_TOOLTIP_WIDTH).stream().map(LiteralText::new).collect(Collectors.toList()));
+            //~ tooltip.addAll(fontRenderer.wrapLines(info, Constants.MAX_TOOLTIP_WIDTH).stream().map(LiteralText::new).collect(Collectors.toList()));
         } else {
             tooltip.add(new LiteralText(info));
         }

--- a/src/main/java/li/cil/tis3d/util/FontRendererUtils.java
+++ b/src/main/java/li/cil/tis3d/util/FontRendererUtils.java
@@ -4,8 +4,9 @@ import li.cil.tis3d.common.Constants;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.font.TextHandler;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 
 import java.util.List;
@@ -27,10 +28,14 @@ public final class FontRendererUtils {
      */
     public static void addStringToTooltip(final String info, final List<Text> tooltip) {
         final MinecraftClient mc = MinecraftClient.getInstance();
-        //~ if (mc != null) {
-        if (false) { // XXX
-            final TextRenderer fontRenderer = mc.textRenderer;
-            //~ tooltip.addAll(fontRenderer.wrapLines(info, Constants.MAX_TOOLTIP_WIDTH).stream().map(LiteralText::new).collect(Collectors.toList()));
+        if (mc != null) {
+            final TextHandler textHandler = mc.textRenderer.getTextHandler();
+            textHandler.wrapLines(info, Constants.MAX_TOOLTIP_WIDTH, Style.EMPTY, false,
+            (style, start, end) -> {
+                final LiteralText text = new LiteralText(info.substring(start, end));
+                text.setStyle(style);
+                tooltip.add(text);
+            });
         } else {
             tooltip.add(new LiteralText(info));
         }

--- a/src/main/java/li/cil/tis3d/util/InventoryUtils.java
+++ b/src/main/java/li/cil/tis3d/util/InventoryUtils.java
@@ -28,7 +28,7 @@ public final class InventoryUtils {
      */
     @Nullable
     public static ItemEntity drop(final World world, final BlockPos pos, final Inventory inventory, final int index, final int count, final Direction towards) {
-        final ItemStack stack = inventory.takeInvStack(index, count);
+        final ItemStack stack = inventory.removeStack(index, count);
         return spawnStackInWorld(world, pos, stack, towards);
     }
 

--- a/src/main/java/li/cil/tis3d/util/WorldUtils.java
+++ b/src/main/java/li/cil/tis3d/util/WorldUtils.java
@@ -4,8 +4,8 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.BlockView;
-import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import net.minecraft.world.chunk.WorldChunk;
 
 import javax.annotation.Nullable;
@@ -23,7 +23,7 @@ public final class WorldUtils {
      * @param pos    the block position to check at.
      * @return whether the block is loaded.
      */
-    public static boolean isBlockLoaded(final IWorld iWorld, final BlockPos pos) {
+    public static boolean isBlockLoaded(final WorldAccess iWorld, final BlockPos pos) {
         final ChunkPos chunkPos = new ChunkPos(pos);
         return iWorld.isChunkLoaded(chunkPos.x, chunkPos.z);
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
         ]
     },
     "depends": {
-        "minecraft": ">=1.15.2 <1.16.0",
+        "minecraft": ">=1.16-rc2",
         "fabricloader": ">=0.4.1",
         "fabric": ">=0.2.7"
     },


### PR DESCRIPTION
Marginal changes compared to 1.15 port. Overview:
* Every `Screen` and `AbstractButton` subclass now takes a `MatrixStack` as the first parameter to `#render`. This however doesn't affect most of the rendering code itself, only native methods like those of `TextRenderer` and `DrawableHelper` need the stack passed through.
* Text rendering now takes a more generic `StringRenderable` (which is also a super-interface of `Text`). See [1].
* Dimensions and their Types have been completely overhauled in this version, so I carefully snipped out the network code dealing with dimensions. See [2].

[1] Unfortunately, tooltips still want a `List<Text>` which the text wrapping functions of `TextHandler` don't directly provide anymore (see `WIP:` commit), but this can be worked around by supplying a custom `LineWrappingConsumer` callback-impl that would create the appropriate line objects.

[2] I've tried for the longest time to wrap my head around how to properly reinstall the dimension id that is sent with each location-based update message, but after lots of failed attempts and a few conversations on Fabricord, I decided to just cut that code completely. I'm a bit anxious about it because I don't know what kind of problem the original code was solving. So far I've done some base-level testing on both integrated and dedicated server and things seem to work fine.

v2: Squashed all build-fixing commits into one, every commit should (hopefully) build now.

Works without changes up to ~~**20w30a**~~ **20w29a**. In 30a, changes to the text rendering cause the manual GUI code to crash.

Questions:
* Was putting I8N helpers in `FontRendererUtils` a good decision?
* Regarding the automatic wrapping of tooltips, how would I cause that to happen in-game to test it?
* Do you remember why update packets kept track of their associated `World`?