### PR TITLE
Add loot tables for blocks so they drop when mined

### DIFF
--- a/src/main/resources/data/tis3d/loot_tables/blocks/casing.json
+++ b/src/main/resources/data/tis3d/loot_tables/blocks/casing.json
@@ -1,0 +1,13 @@
+{
+    "type": "minecraft:block",
+    "pools": [{
+        "rolls": 1,
+        "entries": [{
+            "type": "minecraft:item",
+            "name": "tis3d:casing"
+        }],
+        "conditions": [{
+            "condition": "minecraft:survives_explosion"
+        }]
+    }]
+}

--- a/src/main/resources/data/tis3d/loot_tables/blocks/controller.json
+++ b/src/main/resources/data/tis3d/loot_tables/blocks/controller.json
@@ -1,0 +1,13 @@
+{
+    "type": "minecraft:block",
+    "pools": [{
+        "rolls": 1,
+        "entries": [{
+            "type": "minecraft:item",
+            "name": "tis3d:controller"
+        }],
+        "conditions": [{
+            "condition": "minecraft:survives_explosion"
+        }]
+    }]
+}


### PR DESCRIPTION
This can and should also be applied to the 1.16.1 release, because a lot of mods are currently still stuck on said version due to heavy worldgen chantges from mojang (semver was thrown out the window that day).

1.15.2 and 1.14.4 might also benefit, if they still have players.