### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/li/cil/tis3d/api/prefab/manual/TextureTabIconRenderer.java
+++ b/src/main/java/li/cil/tis3d/api/prefab/manual/TextureTabIconRenderer.java
@@ -1,5 +1,6 @@
 package li.cil.tis3d.api.prefab.manual;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import li.cil.tis3d.api.manual.TabIconRenderer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -25,6 +26,7 @@ public class TextureTabIconRenderer implements TabIconRenderer {
     @Override
     public void render() {
         MinecraftClient.getInstance().getTextureManager().bindTexture(location);
+        RenderSystem.enableBlend();
         final Tessellator t = Tessellator.getInstance();
         final BufferBuilder b = t.getBuffer();
         b.begin(GL11.GL_QUADS, VertexFormats.POSITION_TEXTURE);
@@ -33,5 +35,6 @@ public class TextureTabIconRenderer implements TabIconRenderer {
         b.vertex(16, 0, 0).texture(1, 0).next();
         b.vertex(0, 0, 0).texture(0, 0).next();
         t.draw();
+        RenderSystem.disableBlend();
     }
 }

--- a/src/main/java/li/cil/tis3d/client/render/block/entity/ControllerBlockEntityRenderer.java
+++ b/src/main/java/li/cil/tis3d/client/render/block/entity/ControllerBlockEntityRenderer.java
@@ -2,6 +2,7 @@ package li.cil.tis3d.client.render.block.entity;
 
 import li.cil.tis3d.api.util.RenderUtil;
 import li.cil.tis3d.common.block.entity.ControllerBlockEntity;
+import li.cil.tis3d.util.ColorUtils;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -45,7 +46,7 @@ public final class ControllerBlockEntityRenderer extends BlockEntityRenderer<Con
         final TextRenderer textRenderer = dispatcher.getTextRenderer();
         final float x = -textRenderer.getWidth(str) / 2.0f;
         textRenderer.draw(str, x, 0, 0x20FFFFFF, false, modMat, vcp, true, bg, RenderUtil.maxLight);
-        textRenderer.draw(str, x, 0, -1, false, modMat, vcp, false, 0, RenderUtil.maxLight);
+        textRenderer.draw(str, x, 0, ColorUtils.WHITE, false, modMat, vcp, false, 0, RenderUtil.maxLight);
 
         matrices.pop();
     }


### PR DESCRIPTION
Two small, unrelated fixes. The `-1` was sitting on my 1.15 branch for a while, so I included it.

Previously, the tab icons rendered in solid mode, but because the alpha-keyed background also contained white color, it wasn't apparent.