### PR TITLE
Make private enums public

### DIFF
--- a/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
+++ b/src/main/java/li/cil/tis3d/client/gui/CodeBookGui.java
@@ -674,7 +674,7 @@ public final class CodeBookGui extends Screen {
 
     // --------------------------------------------------------------------- //
 
-    private enum PageChangeType {
+    public enum PageChangeType {
         Previous,
         Next
     }

--- a/src/main/java/li/cil/tis3d/common/integration/minecraft/FurnaceSerialInterfaceProvider.java
+++ b/src/main/java/li/cil/tis3d/common/integration/minecraft/FurnaceSerialInterfaceProvider.java
@@ -44,7 +44,7 @@ public final class FurnaceSerialInterfaceProvider implements SerialInterfaceProv
     private static final class SerialInterfaceFurnace implements SerialInterface {
         private static final String TAG_MODE = "mode";
 
-        private enum FurnaceField {
+        public enum FurnaceField {
             /**
              * How many more ticks the furnace will continue operating before
              * another fuel item must be consumed.
@@ -84,7 +84,7 @@ public final class FurnaceSerialInterfaceProvider implements SerialInterfaceProv
             }
         }
 
-        private enum Mode {
+        public enum Mode {
             PercentageFuel,
             PercentageProgress
         }

--- a/src/main/java/li/cil/tis3d/common/machine/PipeImpl.java
+++ b/src/main/java/li/cil/tis3d/common/machine/PipeImpl.java
@@ -36,7 +36,7 @@ public final class PipeImpl implements Pipe {
      * regardless of whether reader or writer ran first (when they start in
      * the same step).
      */
-    private enum State {
+    public enum State {
         /**
          * Waiting for a reader.
          */

--- a/src/main/java/li/cil/tis3d/common/module/DisplayModule.java
+++ b/src/main/java/li/cil/tis3d/common/module/DisplayModule.java
@@ -90,7 +90,7 @@ public final class DisplayModule extends AbstractModuleWithRotation {
      * Current state of the display module, decides what happens with the next
      * value read on any of the ports.
      */
-    private enum State {
+    public enum State {
         COLOR, X, Y, W, H;
 
         public static final State[] VALUES = State.values();

--- a/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
+++ b/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
@@ -57,7 +57,7 @@ public final class ExecutionModule extends AbstractModuleWithRotation implements
     // --------------------------------------------------------------------- //
     // Computed data
 
-    private enum State {
+    public enum State {
         IDLE,
         ERR,
         RUN,


### PR DESCRIPTION
Make private enums public, for additions (makes mixins easier)
We have ways to access private inner classes, but not private inner enums. This makes this *miles* easier.