### PR TITLE
Optionally disable the program length limit

### DIFF
--- a/src/main/java/li/cil/tis3d/common/CommonConfig.java
+++ b/src/main/java/li/cil/tis3d/common/CommonConfig.java
@@ -39,8 +39,8 @@ public final class CommonConfig {
     /**
      * The maximum number of lines a program may have.
      */
-    @Path("module.execution") @Min(1) @Max(200)
-    @Comment("The maximum number of lines an ASM program for an execution node may have.")
+    @Path("module.execution") @Min(0) @Max(200)
+    @Comment("The maximum number of lines an ASM program for an execution node may have. Use zero to remove the limit.")
     @Translation("maxLinesPerProgram")
     public static int maxLinesPerProgram = 40;
 

--- a/src/main/java/li/cil/tis3d/common/module/execution/compiler/Compiler.java
+++ b/src/main/java/li/cil/tis3d/common/module/execution/compiler/Compiler.java
@@ -32,7 +32,7 @@ public final class Compiler {
         state.clear();
 
         final String[] lines = Iterables.toArray(code, String.class);
-        if (lines.length > CommonConfig.maxLinesPerProgram) {
+        if (lines.length > CommonConfig.maxLinesPerProgram && CommonConfig.maxLinesPerProgram != 0) {
             throw new ParseException(Strings.MESSAGE_TOO_MANY_LINES, CommonConfig.maxLinesPerProgram, 0, 0);
         }
         for (int lineNumber = 0; lineNumber < lines.length; lineNumber++) {


### PR DESCRIPTION
Setting the instruction count limit to zero in the config removes the limit