### PR TITLE
Fix #199 and update forge:markdownmanual to 1.2.5

### DIFF
--- a/common/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
+++ b/common/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
@@ -116,6 +116,12 @@ public final class ExecutionModule extends AbstractModuleWithRotation implements
         }
     }
 
+    public void updatescreen(){
+        state = State.RUN;
+        getCasing().setChanged();
+        sendPartialState();
+    }
+
     @Override
     public void onEnabled() {
         sendFullState();

--- a/common/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
+++ b/common/src/main/java/li/cil/tis3d/common/module/ExecutionModule.java
@@ -116,7 +116,7 @@ public final class ExecutionModule extends AbstractModuleWithRotation implements
         }
     }
 
-    public void updatescreen(){
+    public void updateScreen(){
         state = State.RUN;
         getCasing().setChanged();
         sendPartialState();

--- a/common/src/main/java/li/cil/tis3d/common/module/execution/MachineImpl.java
+++ b/common/src/main/java/li/cil/tis3d/common/module/execution/MachineImpl.java
@@ -24,6 +24,10 @@ public final class MachineImpl implements Machine {
     private final ExecutionModule module;
     private final Map<Target, TargetInterface> interfaces;
 
+    public ExecutionModule getModule(){
+        return this.module;
+    }
+
     // --------------------------------------------------------------------- //
 
     public MachineImpl(final ExecutionModule module, final Face face) {

--- a/common/src/main/java/li/cil/tis3d/common/module/execution/instruction/AbstractMoveInstruction.java
+++ b/common/src/main/java/li/cil/tis3d/common/module/execution/instruction/AbstractMoveInstruction.java
@@ -8,6 +8,7 @@ import li.cil.tis3d.common.module.execution.target.Target;
 abstract class AbstractMoveInstruction implements Instruction {
     protected final Target destination;
 
+
     protected AbstractMoveInstruction(final Target destination) {
         this.destination = destination;
     }
@@ -18,7 +19,12 @@ abstract class AbstractMoveInstruction implements Instruction {
     }
 
     @Override
-    public void onWriteCompleted(final Machine machine, final Port port) {
+    public void onWriteCompleted(final MachineImpl machine, final Port port) {
         machine.getState().pc++;
+        if (machine.getState().pc < 0 || machine.getState().pc >= machine.getState().instructions.size()){
+            machine.getState().pc = 0;
+        }
+        machine.getModule().updatescreen();
     }
+
 }

--- a/common/src/main/java/li/cil/tis3d/common/module/execution/instruction/AbstractMoveInstruction.java
+++ b/common/src/main/java/li/cil/tis3d/common/module/execution/instruction/AbstractMoveInstruction.java
@@ -8,7 +8,6 @@ import li.cil.tis3d.common.module.execution.target.Target;
 abstract class AbstractMoveInstruction implements Instruction {
     protected final Target destination;
 
-
     protected AbstractMoveInstruction(final Target destination) {
         this.destination = destination;
     }
@@ -24,7 +23,7 @@ abstract class AbstractMoveInstruction implements Instruction {
         if (machine.getState().pc < 0 || machine.getState().pc >= machine.getState().instructions.size()){
             machine.getState().pc = 0;
         }
-        machine.getModule().updatescreen();
+        machine.getModule().updateScreen();
     }
 
 }

--- a/common/src/main/java/li/cil/tis3d/common/module/execution/instruction/Instruction.java
+++ b/common/src/main/java/li/cil/tis3d/common/module/execution/instruction/Instruction.java
@@ -41,6 +41,6 @@ public interface Instruction {
      * @param machine the machine the operation finished on.
      * @param port    the port the operation finished on.
      */
-    default void onWriteCompleted(final Machine machine, final Port port) {
+    default void onWriteCompleted(final MachineImpl machine, final Port port) {
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,6 @@ fabric-sodium = { group = "maven.modrinth", name = "sodium", version = "mc1.20.1
 forge-platform = { group = "net.minecraftforge", name = "forge", version.ref = "forge-platform" }
 forge-architectury = { group = "dev.architectury", name = "architectury-forge", version.ref = "architectury" }
 
-forge-manual = { group = "curse.maven", name = "markdownmanual-502485", version = "4719408" }
+forge-manual = { group = "curse.maven", name = "markdownmanual-502485", version = "4873115" }
 
 forge-justEnoughItems = { group = "curse.maven", name = "jei-238222", version = "4690097" }


### PR DESCRIPTION
![2024-12-12_21 31 32](https://github.com/user-attachments/assets/1f00fd5b-045f-4d85-a707-f2d88625adc2)

Now MOV to port seems will cost 2 cycles and PC indicator will be updated correctly.